### PR TITLE
Use https in Commons/Wikipedia URLs explicitly

### DIFF
--- a/app/FrontPage.js
+++ b/app/FrontPage.js
@@ -185,7 +185,7 @@ $.extend( FrontPage.prototype, {
 		if( !input.match( /wiki(m|p)edia\.org/ ) ) {
 			this._api = new NoApi();
 		} else {
-			this._api = new Api( '//commons.wikimedia.org/' );
+			this._api = new Api( 'https://commons.wikimedia.org/' );
 		}
 		this._inputHandler = new InputHandler( this._api );
 

--- a/app/InputHandler.js
+++ b/app/InputHandler.js
@@ -183,16 +183,16 @@ $.extend( InputHandler.prototype, {
 			title;
 
 		if( url.indexOf( 'commons.wikimedia.org/' ) !== -1 ) {
-			wikiUrl = '//commons.wikimedia.org/';
+			wikiUrl = 'https://commons.wikimedia.org/';
 			title = this._extractFilename( url );
 		} else if( regExp0.test( url ) ) {
 			matches = url.match( regExp0 );
 			var domain = ( matches[1] === 'commons' ) ? 'wikimedia' : 'wikipedia';
-			wikiUrl = '//' + matches[1] + '.' + domain + '.org/';
+			wikiUrl = 'https://' + matches[1] + '.' + domain + '.org/';
 			title = this._extractFilename( url );
 		} else if( regExp1.test( url ) ) {
 			matches = url.match( regExp1 );
-			wikiUrl = '//' + matches[1] + '/';
+			wikiUrl = 'https://' + matches[1] + '/';
 
 			title = url.indexOf( 'title=' ) !== -1
 				? url.match( /title=([^&]+)/i )[1]
@@ -200,7 +200,7 @@ $.extend( InputHandler.prototype, {
 
 		} else if( regExp2.test( url ) ) {
 			matches = url.match( regExp2 );
-			wikiUrl = '//' + matches[1] + '.wikipedia.org/';
+			wikiUrl = 'https://' + matches[1] + '.wikipedia.org/';
 			title = this._extractFilename( url );
 		}
 

--- a/app/WikiAsset.js
+++ b/app/WikiAsset.js
@@ -64,7 +64,7 @@ var WikiAsset = declare( Asset, {
 	 */
 	getUrl: function() {
 		var url = ( this._wikiUrl || this._api.getDefaultUrl() ) + 'wiki/' + this._filename;
-		return url.indexOf( 'http' ) === 0 ? url : 'http://' + url;
+		return url.indexOf( 'http' ) === 0 ? url : 'https://' + url;
 	},
 
 	/**

--- a/app/WikiAsset.js
+++ b/app/WikiAsset.js
@@ -63,7 +63,8 @@ var WikiAsset = declare( Asset, {
 	 * @return {string}
 	 */
 	getUrl: function() {
-		return 'http:' + ( this._wikiUrl || this._api.getDefaultUrl() ) + 'wiki/' + this._filename;
+		var url = ( this._wikiUrl || this._api.getDefaultUrl() ) + 'wiki/' + this._filename;
+		return url.indexOf( 'http' ) === 0 ? url : 'http://' + url;
 	},
 
 	/**

--- a/app/WikiAssetPage.js
+++ b/app/WikiAssetPage.js
@@ -172,12 +172,12 @@ $.extend( WikiAssetPage.prototype, {
 			if( href.indexOf( '/w/index.php?title=User:' ) === 0 ) {
 				href = href.replace(
 					/^\/w\/index\.php\?title\=([^&]+).*$/,
-					'http://commons.wikimedia.org/wiki/$1'
+					'https://commons.wikimedia.org/wiki/$1'
 				);
 			} else if( href.indexOf( '/wiki/User:' ) === 0 ) {
-				href = 'http://commons.wikimedia.org' + href;
+				href = 'https://commons.wikimedia.org' + href;
 			} else if( href.indexOf( '//' ) === 0 ) {
-				href = 'http:' + href;
+				href = 'https:' + href;
 			}
 
 			$node.attr( 'href', href );

--- a/tests/app/Api.tests.js
+++ b/tests/app/Api.tests.js
@@ -11,7 +11,7 @@ define(
 
 	QUnit.module( 'Api' );
 
-	var api = new Api( '//commons.wikimedia.org/' );
+	var api = new Api( 'https://commons.wikimedia.org/' );
 
 	/**
 	 * Returns a nodes HTML as plain text.

--- a/tests/app/AttributionGenerator.tests.js
+++ b/tests/app/AttributionGenerator.tests.js
@@ -21,16 +21,16 @@ var testCasesDefinitions = {
 	}],
 	'Helene Fischer 2010.jpg': [{
 		expected: {
-			raw: $( document.createTextNode( 'Fleyx24 (http://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg), „Helene Fischer 2010“, http://creativecommons.org/licenses/by-sa/3.0/legalcode/' ) ),
-			text: $( '<div class="attribution"><span class="attribution-author">Fleyx24</span> <span class="attribution-url">(http://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg)</span>, <span class="attribution-title">„Helene Fischer 2010“</span>, <span class="attribution-licence">http://creativecommons.org/licenses/by-sa/3.0/legalcode/</span></div>' ),
-			html: $( '<div class="attribution"><span class="attribution-author"><a href="http://commons.wikimedia.org/wiki/User:Fleyx24">Fleyx24</a></span>, <span class="attribution-title"><a href="http://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg">„Helene Fischer 2010“</a></span>, <span class="attribution-licence"><a href="http://creativecommons.org/licenses/by-sa/3.0/legalcode/">CC BY-SA 3.0</a></span></div>' )
+			raw: $( document.createTextNode( 'Fleyx24 (https://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg), „Helene Fischer 2010“, http://creativecommons.org/licenses/by-sa/3.0/legalcode/' ) ),
+			text: $( '<div class="attribution"><span class="attribution-author">Fleyx24</span> <span class="attribution-url">(https://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg)</span>, <span class="attribution-title">„Helene Fischer 2010“</span>, <span class="attribution-licence">http://creativecommons.org/licenses/by-sa/3.0/legalcode/</span></div>' ),
+			html: $( '<div class="attribution"><span class="attribution-author"><a href="https://commons.wikimedia.org/wiki/User:Fleyx24">Fleyx24</a></span>, <span class="attribution-title"><a href="https://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg">„Helene Fischer 2010“</a></span>, <span class="attribution-licence"><a href="http://creativecommons.org/licenses/by-sa/3.0/legalcode/">CC BY-SA 3.0</a></span></div>' )
 		}
 	}, {
 		options: { editor: 'edited by Editor' },
 		expected: {
-			raw: $( document.createTextNode( 'Fleyx24 (http://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg), „Helene Fischer 2010“, edited by Editor, http://creativecommons.org/licenses/by-sa/3.0/legalcode/' ) ),
-			text: $( '<div class="attribution"><span class="attribution-author">Fleyx24</span> <span class="attribution-url">(http://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg)</span>, <span class="attribution-title">„Helene Fischer 2010“</span>, <span class="attribution-editor">edited by Editor</span>, <span class="attribution-licence">http://creativecommons.org/licenses/by-sa/3.0/legalcode/</span></div>' ),
-			html: $( '<div class="attribution"><span class="attribution-author"><a href="http://commons.wikimedia.org/wiki/User:Fleyx24">Fleyx24</a></span>, <span class="attribution-title"><a href="http://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg">„Helene Fischer 2010“</a></span>, <span class="attribution-editor">edited by Editor</span>, <span class="attribution-licence"><a href="http://creativecommons.org/licenses/by-sa/3.0/legalcode/">CC BY-SA 3.0</a></span></div>' )
+			raw: $( document.createTextNode( 'Fleyx24 (https://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg), „Helene Fischer 2010“, edited by Editor, http://creativecommons.org/licenses/by-sa/3.0/legalcode/' ) ),
+			text: $( '<div class="attribution"><span class="attribution-author">Fleyx24</span> <span class="attribution-url">(https://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg)</span>, <span class="attribution-title">„Helene Fischer 2010“</span>, <span class="attribution-editor">edited by Editor</span>, <span class="attribution-licence">http://creativecommons.org/licenses/by-sa/3.0/legalcode/</span></div>' ),
+			html: $( '<div class="attribution"><span class="attribution-author"><a href="https://commons.wikimedia.org/wiki/User:Fleyx24">Fleyx24</a></span>, <span class="attribution-title"><a href="https://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg">„Helene Fischer 2010“</a></span>, <span class="attribution-editor">edited by Editor</span>, <span class="attribution-licence"><a href="http://creativecommons.org/licenses/by-sa/3.0/legalcode/">CC BY-SA 3.0</a></span></div>' )
 		}
 	}, {
 		options: { licenceOnly: true },
@@ -42,9 +42,9 @@ var testCasesDefinitions = {
 	}, {
 		options: { licenceLink: false },
 		expected: {
-			raw: $( document.createTextNode( 'Fleyx24 (http://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg), „Helene Fischer 2010“, CC BY-SA 3.0' ) ),
-			text: $( '<div class="attribution"><span class="attribution-author">Fleyx24</span> <span class="attribution-url">(http://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg)</span>, <span class="attribution-title">„Helene Fischer 2010“</span>, <span class="attribution-licence">CC BY-SA 3.0</span></div>' ),
-			html: $( '<div class="attribution"><span class="attribution-author"><a href="http://commons.wikimedia.org/wiki/User:Fleyx24">Fleyx24</a></span>, <span class="attribution-title"><a href="http://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg">„Helene Fischer 2010“</a></span>, <span class="attribution-licence">CC BY-SA 3.0</span></div>' )
+			raw: $( document.createTextNode( 'Fleyx24 (https://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg), „Helene Fischer 2010“, CC BY-SA 3.0' ) ),
+			text: $( '<div class="attribution"><span class="attribution-author">Fleyx24</span> <span class="attribution-url">(https://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg)</span>, <span class="attribution-title">„Helene Fischer 2010“</span>, <span class="attribution-licence">CC BY-SA 3.0</span></div>' ),
+			html: $( '<div class="attribution"><span class="attribution-author"><a href="https://commons.wikimedia.org/wiki/User:Fleyx24">Fleyx24</a></span>, <span class="attribution-title"><a href="https://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg">„Helene Fischer 2010“</a></span>, <span class="attribution-licence">CC BY-SA 3.0</span></div>' )
 		}
 	}, {
 		options: { editor: 'edited by Editor', licenceOnly: true },
@@ -56,9 +56,9 @@ var testCasesDefinitions = {
 	}, {
 		options: { editor: 'edited by Editor', licenceLink: false },
 		expected: {
-			raw: $( document.createTextNode( 'Fleyx24 (http://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg), „Helene Fischer 2010“, edited by Editor, CC BY-SA 3.0' ) ),
-			text: $( '<div class="attribution"><span class="attribution-author">Fleyx24</span> <span class="attribution-url">(http://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg)</span>, <span class="attribution-title">„Helene Fischer 2010“</span>, <span class="attribution-editor">edited by Editor</span>, <span class="attribution-licence">CC BY-SA 3.0</span></div>' ),
-			html: $( '<div class="attribution"><span class="attribution-author"><a href="http://commons.wikimedia.org/wiki/User:Fleyx24">Fleyx24</a></span>, <span class="attribution-title"><a href="http://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg">„Helene Fischer 2010“</a></span>, <span class="attribution-editor">edited by Editor</span>, <span class="attribution-licence">CC BY-SA 3.0</span></div>' )
+			raw: $( document.createTextNode( 'Fleyx24 (https://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg), „Helene Fischer 2010“, edited by Editor, CC BY-SA 3.0' ) ),
+			text: $( '<div class="attribution"><span class="attribution-author">Fleyx24</span> <span class="attribution-url">(https://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg)</span>, <span class="attribution-title">„Helene Fischer 2010“</span>, <span class="attribution-editor">edited by Editor</span>, <span class="attribution-licence">CC BY-SA 3.0</span></div>' ),
+			html: $( '<div class="attribution"><span class="attribution-author"><a href="https://commons.wikimedia.org/wiki/User:Fleyx24">Fleyx24</a></span>, <span class="attribution-title"><a href="https://commons.wikimedia.org/wiki/File:Helene Fischer 2010.jpg">„Helene Fischer 2010“</a></span>, <span class="attribution-editor">edited by Editor</span>, <span class="attribution-licence">CC BY-SA 3.0</span></div>' )
 		}
 	}, {
 		options: { licenceOnly: true, licenceLink: false },
@@ -70,9 +70,9 @@ var testCasesDefinitions = {
 	}],
 	'JapaneseToiletControlPanel.jpg': [{
 		expected: {
-			raw: $( document.createTextNode( 'Chris 73 / Wikimedia Commons (http://commons.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg), „JapaneseToiletControlPanel“, http://creativecommons.org/licenses/by-sa/3.0/legalcode/' ) ),
-			text: $( '<div class="attribution">Chris 73 / Wikimedia Commons <span class="attribution-url">(http://commons.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg)</span>, <span class="attribution-title">„JapaneseToiletControlPanel“</span>, <span class="attribution-licence">http://creativecommons.org/licenses/by-sa/3.0/legalcode/</span></div>' ),
-			html: $( '<div class="attribution"><a href="http://commons.wikimedia.org/wiki/User:Chris_73">Chris 73</a> / <a href="http://commons.wikimedia.org/">Wikimedia Commons</a>, <span class="attribution-title"><a href="http://commons.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg">„JapaneseToiletControlPanel“</a></span>, <span class="attribution-licence"><a href="http://creativecommons.org/licenses/by-sa/3.0/legalcode/">CC BY-SA 3.0</a></span></div>' )
+			raw: $( document.createTextNode( 'Chris 73 / Wikimedia Commons (https://commons.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg), „JapaneseToiletControlPanel“, http://creativecommons.org/licenses/by-sa/3.0/legalcode/' ) ),
+			text: $( '<div class="attribution">Chris 73 / Wikimedia Commons <span class="attribution-url">(https://commons.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg)</span>, <span class="attribution-title">„JapaneseToiletControlPanel“</span>, <span class="attribution-licence">http://creativecommons.org/licenses/by-sa/3.0/legalcode/</span></div>' ),
+			html: $( '<div class="attribution"><a href="https://commons.wikimedia.org/wiki/User:Chris_73">Chris 73</a> / <a href="http://commons.wikimedia.org/">Wikimedia Commons</a>, <span class="attribution-title"><a href="https://commons.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg">„JapaneseToiletControlPanel“</a></span>, <span class="attribution-licence"><a href="http://creativecommons.org/licenses/by-sa/3.0/legalcode/">CC BY-SA 3.0</a></span></div>' )
 		}
 	}],
 	'1871_Proclamation_of_the_German_Empire.jpg': [{

--- a/tests/app/InputHandler.local.tests.js
+++ b/tests/app/InputHandler.local.tests.js
@@ -26,7 +26,7 @@ define(
 			],
 			expected: {
 				file: 'File:Helene_Fischer_2010.jpg',
-				wikiUrl: '//commons.wikimedia.org/'
+				wikiUrl: 'https://commons.wikimedia.org/'
 			}
 		}, {
 			input: [
@@ -34,7 +34,7 @@ define(
 			],
 			expected: {
 				file: 'File:Helene_Fischer_2010.jpg',
-				wikiUrl: '//commons.wikimedia.org/'
+				wikiUrl: 'https://commons.wikimedia.org/'
 			}
 		}, {
 			input: [
@@ -47,7 +47,7 @@ define(
 			],
 			expected: {
 				file: 'File:JapaneseToiletControlPanel.jpg',
-				wikiUrl: '//commons.wikimedia.org/'
+				wikiUrl: 'https://commons.wikimedia.org/'
 			}
 		}, {
 			input: [
@@ -60,7 +60,7 @@ define(
 			],
 			expected: {
 				file: 'File:Gerardus_t\'_Hooft_at_Harvard.jpg',
-				wikiUrl: '//commons.wikimedia.org/'
+				wikiUrl: 'https://commons.wikimedia.org/'
 			}
 		}, {
 			input: [
@@ -72,7 +72,7 @@ define(
 			],
 			expected: {
 				file: 'File:"Граничар"_-_Туховища.JPG',
-				wikiUrl: '//commons.wikimedia.org/'
+				wikiUrl: 'https://commons.wikimedia.org/'
 			}
 		}, {
 			input: [
@@ -80,7 +80,7 @@ define(
 			],
 			expected: {
 				file: 'File:"Граничар"_-_Туховища.JPG',
-				wikiUrl: '//commons.wikimedia.org/'
+				wikiUrl: 'https://commons.wikimedia.org/'
 			}
 		}, {
 			input: [
@@ -94,7 +94,7 @@ define(
 			],
 			expected: {
 				file: 'File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg',
-				wikiUrl: '//de.wikipedia.org/'
+				wikiUrl: 'https://de.wikipedia.org/'
 			}
 		}, {
 			input: [
@@ -107,7 +107,7 @@ define(
 			],
 			expected: {
 				file: 'Datei:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg',
-				wikiUrl: '//de.wikipedia.org/'
+				wikiUrl: 'https://de.wikipedia.org/'
 			}
 		}, {
 			input: [
@@ -177,7 +177,7 @@ define(
 					'http://en.wikipedia.org/wiki/%3F_(film)'
 				],
 				expected: {
-					wikiUrl: '//en.wikipedia.org/'
+					wikiUrl: 'https://en.wikipedia.org/'
 				}
 			},{
 				input: [
@@ -191,7 +191,7 @@ define(
 					'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de'
 				],
 				expected: {
-					wikiUrl: '//de.wikipedia.org/'
+					wikiUrl: 'https://de.wikipedia.org/'
 				}
 			}
 		];

--- a/tests/app/InputHandler.tests.js
+++ b/tests/app/InputHandler.tests.js
@@ -11,7 +11,7 @@ define(
 
 	QUnit.module( 'InputHandler' );
 
-	var api = new Api( '//commons.wikimedia.org/' );
+	var api = new Api( 'https://commons.wikimedia.org/' );
 
 	var testCases = [
 		{
@@ -26,7 +26,7 @@ define(
 			],
 			expected: {
 				file: 'File:Helene_Fischer_2010.jpg',
-				wikiUrl: '//commons.wikimedia.org/'
+				wikiUrl: 'https://commons.wikimedia.org/'
 			}
 		}, {
 			input: [
@@ -34,7 +34,7 @@ define(
 			],
 			expected: {
 				file: 'File:Helene_Fischer_2010.jpg',
-				wikiUrl: '//commons.wikimedia.org/'
+				wikiUrl: 'https://commons.wikimedia.org/'
 			}
 		}, {
 			input: [
@@ -47,7 +47,7 @@ define(
 			],
 			expected: {
 				file: 'File:JapaneseToiletControlPanel.jpg',
-				wikiUrl: '//commons.wikimedia.org/'
+				wikiUrl: 'https://commons.wikimedia.org/'
 			}
 		}, {
 			input: [
@@ -60,7 +60,7 @@ define(
 			],
 			expected: {
 				file: 'File:Gerardus_t\'_Hooft_at_Harvard.jpg',
-				wikiUrl: '//commons.wikimedia.org/'
+				wikiUrl: 'https://commons.wikimedia.org/'
 			}
 		}, {
 			input: [
@@ -72,7 +72,7 @@ define(
 			],
 			expected: {
 				file: 'File:"Граничар"_-_Туховища.JPG',
-				wikiUrl: '//commons.wikimedia.org/'
+				wikiUrl: 'https://commons.wikimedia.org/'
 			}
 		}, {
 			input: [
@@ -80,7 +80,7 @@ define(
 			],
 			expected: {
 				file: 'File:"Граничар"_-_Туховища.JPG',
-				wikiUrl: '//commons.wikimedia.org/'
+				wikiUrl: 'https://commons.wikimedia.org/'
 			}
 		}, {
 			input: [
@@ -94,7 +94,7 @@ define(
 			],
 			expected: {
 				file: 'File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg',
-				wikiUrl: '//de.wikipedia.org/'
+				wikiUrl: 'https://de.wikipedia.org/'
 			}
 		}, {
 			input: [
@@ -107,7 +107,7 @@ define(
 			],
 			expected: {
 				file: 'Datei:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg',
-				wikiUrl: '//de.wikipedia.org/'
+				wikiUrl: 'https://de.wikipedia.org/'
 			}
 		}, {
 			input: [
@@ -177,7 +177,7 @@ define(
 					'http://en.wikipedia.org/wiki/%3F_(film)'
 				],
 				expected: {
-					wikiUrl: '//en.wikipedia.org/'
+					wikiUrl: 'https://en.wikipedia.org/'
 				}
 			},{
 				input: [
@@ -191,7 +191,7 @@ define(
 					'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de'
 				],
 				expected: {
-					wikiUrl: '//de.wikipedia.org/'
+					wikiUrl: 'https://de.wikipedia.org/'
 				}
 			}
 		];

--- a/tests/app/WikiAsset.tests.js
+++ b/tests/app/WikiAsset.tests.js
@@ -1,0 +1,37 @@
+/**
+ * @licence GNU GPL v3
+ * @author Leszek Manicki < leszek.manicki@wikimedia.de >
+ */
+( function( QUnit ) {
+'use strict';
+
+define(
+	['jquery', 'app/WikiAsset', 'tests/assets'],
+	function( $, WikiAsset, testAssets ) {
+
+	QUnit.module( 'WikiAsset' );
+
+	QUnit.test( 'getUrl()', function( assert ) {
+
+		var testCases = {
+			'LRO_Tycho_Central_Peak.jpg': {
+				expected: 'https://commons.wikimedia.org/wiki/File:LRO_Tycho_Central_Peak.jpg'
+			},
+			'Helene Fischer 2010.jpg': {
+				expected: 'https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg'
+			},
+			'Hektor_Philippi.JPG': {
+				expected: 'https://de.wikipedia.org/wiki/Datei:Hektor_Philippi.JPG'
+			}
+		};
+
+		$.each( testCases, function ( filename, testCase ) {
+			var asset = testAssets[filename];
+			assert.ok( asset.getUrl(), testCase.expected, 'URL "' + asset.getUrl() + '" matches.' )
+		} );
+
+	} );
+
+} );
+
+}( QUnit ) );

--- a/tests/assets.js
+++ b/tests/assets.js
@@ -18,7 +18,7 @@ function( $, Api, Asset, LicenceStore, LICENCES, NoApi, WikiAsset, Author, confi
 
 config.custom.licenceStore = new LicenceStore( LICENCES );
 
-var api = new Api( '//commons.wikimedia.org/' ),
+var api = new Api( 'https://commons.wikimedia.org/' ),
 	noApi = new NoApi();
 
 return {
@@ -47,7 +47,7 @@ return {
 		'bitmap',
 		config.custom.licenceStore.getLicence( 'cc-by-sa-3.0' ),
 		'Helene Fischer 2010',
-		[new Author( $( '<a href="http://commons.wikimedia.org/wiki/User:Fleyx24">Fleyx24</a>' ) )],
+		[new Author( $( '<a href="https://commons.wikimedia.org/wiki/User:Fleyx24">Fleyx24</a>' ) )],
 		null,
 		null,
 		api
@@ -57,10 +57,10 @@ return {
 		'bitmap',
 		config.custom.licenceStore.getLicence( 'cc-by-sa-3.0' ),
 		'JapaneseToiletControlPanel',
-		[new Author( $( '<a href="http://commons.wikimedia.org/wiki/User:Chris_73">Chris 73</a>' ) )],
+		[new Author( $( '<a href="https://commons.wikimedia.org/wiki/User:Chris_73">Chris 73</a>' ) )],
 		null,
 		// Complex attribution and attribution differs from author:
-		$( '<a href="http://commons.wikimedia.org/wiki/User:Chris_73">Chris 73</a> / <a href="http://commons.wikimedia.org/">Wikimedia Commons</a>' ),
+		$( '<a href="https://commons.wikimedia.org/wiki/User:Chris_73">Chris 73</a> / <a href="http://commons.wikimedia.org/">Wikimedia Commons</a>' ),
 		api
 	),
 	'13-09-29-nordfriesisches-wattenmeer-RalfR-15.jpg': new WikiAsset(
@@ -70,7 +70,7 @@ return {
 		config.custom.licenceStore.getLicence( 'cc-by-sa-3.0' ),
 		'13-09-29-nordfriesisches-wattenmeer-RalfR-15',
 		// Complex author:
-		[new Author( $( '<div/>' ).html( '©&nbsp;<a href="http://commons.wikimedia.org/wiki/User:Ralf_Roletschek">Ralf Roletschek</a> - <a rel="nofollow" href="http://www.fahrradmonteur.de">Fahrradtechnik und Fotografie</a>' ).contents() )],
+		[new Author( $( '<div/>' ).html( '©&nbsp;<a href="https://commons.wikimedia.org/wiki/User:Ralf_Roletschek">Ralf Roletschek</a> - <a rel="nofollow" href="http://www.fahrradmonteur.de">Fahrradtechnik und Fotografie</a>' ).contents() )],
 		null,
 		null,
 		api
@@ -92,10 +92,10 @@ return {
 		// Features additional newer CC-BY-SA licence, preferring non-SA licence:
 		config.custom.licenceStore.getLicence( 'cc-by-2.0-de' ),
 		'Inisheer Gardens 2002 dry-stone walls',
-		[new Author( $( '<a href="http://commons.wikimedia.org/wiki/User:Arcimboldo">Eckhard Pecher</a>' ) )],
+		[new Author( $( '<a href="https://commons.wikimedia.org/wiki/User:Arcimboldo">Eckhard Pecher</a>' ) )],
 		null,
 		// Simple attribution:
-		$( '<a href="http://commons.wikimedia.org/wiki/User:Arcimboldo">Eckhard Pecher</a>' ),
+		$( '<a href="https://commons.wikimedia.org/wiki/User:Arcimboldo">Eckhard Pecher</a>' ),
 		api
 	),
 	'Wien Karlsplatz3.jpg': new WikiAsset(
@@ -104,7 +104,7 @@ return {
 		config.custom.licenceStore.getLicence( 'cc-by-2.0-de' ),
 		'Wien Karlsplatz3',
 		// Strip "(talk)" link:
-		[new Author( $( '<a href="http://commons.wikimedia.org/wiki/User:Ikar.us">Ikar.us</a>' ) )],
+		[new Author( $( '<a href="https://commons.wikimedia.org/wiki/User:Ikar.us">Ikar.us</a>' ) )],
 		null,
 		null,
 		api
@@ -126,7 +126,7 @@ return {
 		config.custom.licenceStore.getLicence( 'cc-by-3.0' ),
 		'Gerardus t\' Hooft at Harvard',
 		// Inter-wiki links:
-		[new Author( $( '<div/>' ).html( '<a href="http://en.wikipedia.org/wiki/User:Lumidek">Lumidek</a> at <a href="http://en.wikipedia.org/wiki/">English Wikipedia</a>' ).contents() )],
+		[new Author( $( '<div/>' ).html( '<a href="https://en.wikipedia.org/wiki/User:Lumidek">Lumidek</a> at <a href="https://en.wikipedia.org/wiki/">English Wikipedia</a>' ).contents() )],
 		null,
 		null,
 		api
@@ -148,7 +148,7 @@ return {
 		// Unsupported licence derivative CC-BY-3.0-LU:
 		config.custom.licenceStore.getLicence( 'cc' ),
 		'NatMonumFengegKapell',
-		[new Author( $( '<div/>' ).html( '<a href="http://lb.wikipedia.org/wiki/User:Pecalux">Pecalux</a> at <a href="http://lb.wikipedia.org">lb.wikipedia</a>' ).contents() )],
+		[new Author( $( '<div/>' ).html( '<a href="https://lb.wikipedia.org/wiki/User:Pecalux">Pecalux</a> at <a href="http://lb.wikipedia.org">lb.wikipedia</a>' ).contents() )],
 		null,
 		null,
 		api
@@ -170,7 +170,7 @@ return {
 		// Licence not detectable:
 		null,
 		'03602 - Monti, Gaetano - Allegoria (1832) - Porta Venezia, Milano - Foto Giovanni Dall\'Orto 23-Jun-2007',
-		[ new Author( $( '<a href="http://commons.wikimedia.org/wiki/User:G.dallorto">G.dallorto</a>' ) ) ],
+		[ new Author( $( '<a href="https://commons.wikimedia.org/wiki/User:G.dallorto">G.dallorto</a>' ) ) ],
 		null,
 		null,
 		api
@@ -192,7 +192,7 @@ return {
 		'audio',
 		config.custom.licenceStore.getLicence( 'cc-by-sa-3.0' ),
 		'05 Air from Suite in C minor',
-		[new Author( $( '<a href="http://commons.wikimedia.org/wiki/User:Bdegazio">Bdegazio</a>' ) )],
+		[new Author( $( '<a href="https://commons.wikimedia.org/wiki/User:Bdegazio">Bdegazio</a>' ) )],
 		null,
 		null,
 		api
@@ -214,9 +214,9 @@ return {
 		config.custom.licenceStore.getLicence( 'cc-by-sa-3.0' ),
 		'Air France A380 F-HPJA',
 		// Author's contains HTML where the internal user page link is not on the top-most DOM level:
-		[new Author( $( '<a href="http://commons.wikimedia.org/wiki/User:Jovianeye">Joe Ravi</a>') )],
+		[new Author( $( '<a href="https://commons.wikimedia.org/wiki/User:Jovianeye">Joe Ravi</a>') )],
 		null,
-		$( '<a href="http://commons.wikimedia.org/wiki/User:Jovianeye">Joe Ravi</a>' ),
+		$( '<a href="https://commons.wikimedia.org/wiki/User:Jovianeye">Joe Ravi</a>' ),
 		api
 	),
 	'Seilsäge.jpg': new WikiAsset(

--- a/tests/assets.js
+++ b/tests/assets.js
@@ -230,7 +230,7 @@ return {
 		null,
 		api,
 		// Local Wikipedia:
-		'//de.wikipedia.org/'
+		'https://de.wikipedia.org/'
 	),
 	'Hektor_Philippi.JPG': new WikiAsset(
 		// Using "File:" prefix:
@@ -243,7 +243,7 @@ return {
 		null,
 		null,
 		api,
-		'//de.wikipedia.org/'
+		'https://de.wikipedia.org/'
 	),
 	'1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg': new WikiAsset(
 		'Datei:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg',
@@ -255,7 +255,7 @@ return {
 		null,
 		null,
 		api,
-		'//de.wikipedia.org/'
+		'https://de.wikipedia.org/'
 	),
 	'Fiesta-Zuschauer Z1.jpeg': new WikiAsset(
 		'Datei:Fiesta-Zuschauer Z1.jpeg',
@@ -267,7 +267,7 @@ return {
 		null,
 		null,
 		api,
-		'//de.wikipedia.org/'
+		'https://de.wikipedia.org/'
 	)
 // TODO: Edge cases
 /*

--- a/tests/index.html
+++ b/tests/index.html
@@ -28,7 +28,8 @@
 			'tests/app/InputHandler.local.tests',
 			'tests/app/Questionnaire.tests',
 			'tests/app/QuestionnairePage.tests',
-			'tests/app/LicenceStore.tests'
+			'tests/app/LicenceStore.tests',
+			'tests/app/WikiAsset.tests'
 		], function() {
 			QUnit.load();
 			QUnit.start();


### PR DESCRIPTION
This is a pull request onto `mock-api-in-tests`, as I see this change as a part of improving the testing of the code. I can change this to be a change against master, if preferred.

The background here is that tests making AJAX calls to Commons/Wikipedia APIs have been falling when run from command line (as pointed out in https://phabricator.wikimedia.org/T107023). The reason of these failures is PhantomJS understanding "protocol-relative" urls to APIs differently than "real" browser (namely, PhantomJS attempts to read local files when given such urls).

Apart from this issue, I think it is rather redundant to use protocol-relative URLs when Commons and Wikipedias are actually always offering access using HTTPS. Therefore I think it makes more sense to explicitly use https-prefixed URLs to Commons and Wikipedia pages and APIs instead of protocol-relative ones.

Will close https://phabricator.wikimedia.org/T107023, and also https://phabricator.wikimedia.org/T105295.