### PR TITLE
Change test runner to qunit-phantomjs-runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ node_js:
 
 sudo: false
 
-install: travis_retry npm install --save-dev node-qunit-phantomjs
+install: travis_retry npm install --save-dev qunit-phantomjs-runner
 
-script: ./node_modules/node-qunit-phantomjs/bin/node-qunit-phantomjs ./tests/index.html
+script: phantomjs ./node_modules/qunit-phantomjs-runner/runner.js ./tests/index.html

--- a/README.md
+++ b/README.md
@@ -26,4 +26,12 @@ Coding style adheres to the [Wikibase coding conventions](http://www.mediawiki.o
 
 ### Testing
 
-QUnit tests are located in the <code>tests</code> directory. Before merging changes, tests should be run by accessing <code>/tests/index.html</code> in a browser.
+QUnit tests are located in the <code>tests</code> directory. Before merging changes, tests should be run by accessing <code>/tests/index.html</code> in a browser or from command line using [qunit-phantomjs-runner](https://github.com/jonkemp/qunit-phantomjs-runner):
+```bash
+phantomjs path/to/runner.js ./tests/index.html
+```
+
+There are tests for methods making calls to Commons API included in `tests/api-tests.html`. When running tests with `qunit-phantomjs-runner`, default timeout (5 seconds) may be hit. Use higher timeout value in such case (e.g. 10 seconds):
+```bash
+phantomjs path/to/runner.js ./tests/api-tests.html 10
+```


### PR DESCRIPTION
This is a pull request onto `mock-api-in-tests`, as I see this change as a part of improving the testing of the code. I can change this to be a change against master, if preferred.

I suggest using https://github.com/jonkemp/qunit-phantomjs-runner as it is more flexible than https://github.com/jonkemp/node-qunit-phantomjs we've been using so far. Namely, the former allows to change the timeout of the test run, which might be required when testing methods making API calls.
Moreover, the latter runner is actually only a simple wrapper over the qunit-phantomjs-runner.

Note: I have intentionally NOT set TravisCI to run `tests/api-tests.html`. I am not sure whether we want to make bunch of calls to Commons API whenever change is pushed to the repository. I believe "local" API tests should be enough for most cases.