### PR TITLE
While trimming empty nodes of the template, check if current element is not empty

### DIFF
--- a/app/WikiAssetPage.js
+++ b/app/WikiAssetPage.js
@@ -195,6 +195,9 @@ $.extend( WikiAssetPage.prototype, {
 	 * @return {jQuery}
 	 */
 	_trimNodeList: function( $nodes ) {
+		if( $nodes.length === 0 ) {
+			return $nodes;
+		}
 		if( $.trim( $nodes.eq( 0 ).text() ) === '' ) {
 			$nodes = $nodes.not( $nodes.eq( 0 ) );
 		}


### PR DESCRIPTION
Fixes: https://phabricator.wikimedia.org/T108029
Passing empty attribution element caused an infinite loop