### PR TITLE
Add user input for author to the attribution.

### DIFF
--- a/redesign/js/app/DialogueEvaluation.js
+++ b/redesign/js/app/DialogueEvaluation.js
@@ -31,12 +31,16 @@ $.extend( DialogueEvaluation.prototype, {
 	},
 
 	_unknownAuthor: function() {
-		return this._getResult( 'author', 'no-author' ) === 'true';
+		return this._getResult( 'author', 'no-author' ) === 'true' || this._getResult( 'author', 'author' );
+	},
+
+	_unknownAuthorName: function() {
+		return this._getResult( 'author', 'author' ) || Messages.t( 'evaluation.anonymous' );
 	},
 
 	_getAuthor: function() {
 		if( this._unknownAuthor() ) {
-			return Messages.t( 'evaluation.anonymous' );
+			return this._unknownAuthorName();
 		}
 
 		return this._asset.getAuthors().map( function( author ) {
@@ -46,7 +50,7 @@ $.extend( DialogueEvaluation.prototype, {
 
 	_getHtmlAuthor: function() {
 		if( this._unknownAuthor() ) {
-			return Messages.t( 'evaluation.anonymous' );
+			return this._unknownAuthorName();
 		}
 
 		return this._asset.getAuthors().map( function( author ) {

--- a/redesign/tests/app/DialogueEvaluation.tests.js
+++ b/redesign/tests/app/DialogueEvaluation.tests.js
@@ -131,6 +131,11 @@ QUnit.test( 'attribution shows "anonymous" for unknown author', function( assert
 	assert.ok( attributionContains( evaluation, Messages.t( 'evaluation.anonymous' ) ) );
 } );
 
+QUnit.test( 'online attribution shows the author the user entered', function( assert ) {
+	var evaluation = newEvaluation( {}, { author: { author: 'Meh' } } );
+	assert.ok( attributionContains( evaluation, 'Meh' ) );
+} );
+
 QUnit.test( 'has type of use information in the DOs section', function( assert ) {
 	var printEvaluation = newEvaluation( {}, { 'typeOfUse': { type: 'print' } } ),
 		onlineEvaluation = newEvaluation( {}, { 'typeOfUse': { type: 'online' } } );


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T119625
Demo: http://tools.wmflabs.org/file-reuse-test/fix_author/redesign/
Example image: `https://commons.wikimedia.org/wiki/File:%22Le_Tour_de_France%22,_a_cartoon_sequence_Wellcome_L0053073.jpg`