### PR TITLE
Call scrolling animation on both html and body elements, so it works …

### DIFF
--- a/redesign/js/app/FileForm.js
+++ b/redesign/js/app/FileForm.js
@@ -52,7 +52,7 @@ $.extend( FileForm.prototype, {
 	},
 
 	_scrollTo: function( position ) {
-		$( 'body' ).animate( {
+		$( 'html, body' ).animate( {
 			scrollTop: position
 		}, 700 );
 	},

--- a/redesign/js/main.js
+++ b/redesign/js/main.js
@@ -44,11 +44,11 @@ var fileForm = new FileForm( $( '#file-form' ), $( '#results-screen' ) );
 fileForm.init();
 
 var $howItWorks = $( '#how-it-works-screen' ),
-	$body = $( 'body' );
+	$scrollingElements = $( 'html, body' );
 
 $( '#how-it-works-button' ).click( function() {
 	$howItWorks.show();
-	$body
+	$scrollingElements
 		.scrollTop( $howItWorks.height() )
 		.animate( {
 			scrollTop: 0
@@ -57,16 +57,15 @@ $( '#how-it-works-button' ).click( function() {
 } );
 
 $( '#how-it-works-screen .close' ).click( function() {
-	$body.animate(
+	$scrollingElements.animate(
 		{
 			scrollTop: $howItWorks.height()
 		},
-		700,
-		function() {
-			$howItWorks.hide();
-			$body.scrollTop( 0 );
-		}
-	);
+		700
+	).promise().done( function() {
+		$howItWorks.hide();
+		$scrollingElements.scrollTop( 0 );
+	} );
 } );
 
 $( '#file-form-input' ).on( 'input', function() {


### PR DESCRIPTION
…in all browsers

Task: https://phabricator.wikimedia.org/T119073
Note that as mentioned in the comment on phabricator, the same problem caused that neither scrolling after clicking "Los" nor after clicking "Wie funktioniert das?"
Demo: https://tools.wmflabs.org/file-reuse-test/all-browser-scrolling/redesign

I have tried to figure out when the scrolling had actually stopped to work in Firefox (and probably at least in IE too) but I failed (scrolling animation code seems to have been more or less the same from the very start = animation would have never worked, which is not true).
Anyway, the reason why the animation scrolled properly in some browsers (e.g. Chrome) but not in others (Firefox etc) is that they set the overflow on different element (`body` vs `html`). This has been discussed for instance [here](https://stackoverflow.com/questions/8149155/animate-scrolltop-not-working-in-firefox).
The solution I used here is not the most elegant one (animation is fired on two elements, and the callback after closing "how it works" had to be changed slightly so it called only once) but seems to work for me. The feature detection suggested in https://stackoverflow.com/a/21583714 seems reasonable but on the other hand it'd be a bit silly to have to scroll window first a bit in order to do the proper scrolling.

Tested on Ubuntu with Firefox 42 and Chromium 45.
Testing in other browsers (especially Safari and IE) would be appreciated. Not tested yet in Opera as well.