### PR TITLE
Add pop-up box with more private-use information

### DIFF
--- a/redesign/index.html
+++ b/redesign/index.html
@@ -175,6 +175,22 @@
         </div>
       </div>
     </div>
+
+    <div class="modal ag-modal fade" id="private-use-modal">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title">Private Nutzung und andere Ausnahmen</h4>
+                </div>
+
+                <div class="modal-body">
+                    <p>Dieses Tool hilft Ihnen dabei, den korrekten Lizenhinweis für frei lizenzierte Inhalte zu generieren. Sie benötigen diesen Lizenzhinweis, wenn Sie ein frei lizenziertes Werk nachnutzen und veröffentlichen möchten. Unter einer Veröffentlichung versteht man z.B. das Posten eines Bildes auf Ihrem Blog, in sozialen Netzwerken oder die Abbildung in einem Druckerzeugnis. Möchten Sie den gewählten Inhalt in einem rein <a href="https://de.wikipedia.org/wiki/Privatkopie" target="_blank">privaten Kontext</a> nutzen und nicht öffentlich zugänglich machen, brauchen Sie sich nicht an die Lizenzbedingungen zu halten und somit auch keinen Lizenzhinweis anbringen. Wir möchten Ihnen dies trotzdem empfehlen. Unter einer privaten Nutzung versteht man z.B. das Versenden an Freunde per E-Mail oder den Druck eines Bildes für die eigenen Wohnräume.</p>
+                    <p>Weitere gesetzliche Ausnahmen gelten für die Nachnutzung in <a href="https://de.wikipedia.org/wiki/Schranken_des_Urheberrechts#.C3.96ffentliche_Zug.C3.A4nglichmachung_f.C3.BCr_Unterricht_und_Forschung.2C_.C2.A7_52a_UrhG" target="_blank">wissenschaftlichen Publikationen</a> oder als <a href="https://de.wikipedia.org/wiki/Schranken_des_Urheberrechts#Zitate.2C_.C2.A7_51_UrhG">Zitat</a>. In diesen Fällen können Sie wählen, ob Sie nur die gesetzlichen Vorgaben oder stattdessen die Lizenzbedingungen der Creative-Commons-Lizenz einhalten möchten.</p>
+                </div>
+            </div>
+        </div>
+    </div>
     <div class="screen display-none" id="results-screen"></div>
 
     <script src="js/bundle.min.js"></script>

--- a/redesign/js/app/views/AttributionDialogueView.js
+++ b/redesign/js/app/views/AttributionDialogueView.js
@@ -13,7 +13,8 @@ var AttributionDialogueView = function( asset ) {
 
 	this._privateUseBox = new InfoBoxView(
 		'private-use',
-		Messages.t( 'info-box.private-use' ),
+		Messages.t( 'info-box.private-use' ) +
+			'<a class="track-click" data-track-category="Navigation" data-track-event="Private Use" href="#" data-toggle="modal" data-target="#private-use-modal">' + Messages.t( 'info-box.private-use-more-link' ) + '</a>',
 		'<button class="green-btn small-btn close-info hide-forever">' + Messages.t( 'info-box.dont-show-again' ) + '</button>'
 	);
 

--- a/redesign/js/i18n.json
+++ b/redesign/js/i18n.json
@@ -10,7 +10,8 @@
       "licence-not-recognized": "Es tut uns leid, aber dieses Bild wird aufgrund des Lizenzformats derzeit noch nicht unterstützt."
     },
     "info-box": {
-      "private-use": "Wenn Sie das Bild für private Zwecke nutzen möchten, ist die Angabe eines Lizenzhinweises nicht nötig. <a href=\"#\">&#8594; MEHR ERFAHREN</a>",
+      "private-use": "Wenn Sie das Bild für private Zwecke nutzen möchten, ist die Angabe eines Lizenzhinweises nicht nötig.",
+      "private-use-more-link": "&#8594; MEHR ERFAHREN",
       "dont-show-again": "Hinweis nicht mehr anzeigen",
       "understood-and-close": "Verstanden und schließen",
       "ported-licence": "Bestimmte Creative-Commons-Lizenzen wurden in speziellen Länderversionen veröffentlicht, so genannte portierte Lizenzen. Das von Ihnen angefragte Werk wurde unter einer solchen portierten Lizenz veröffentlicht. Es wurde nicht geprüft, ob die Lizenzpflichten dieser Länderversion der deutschen Sprachversion entsprechen. Sie können den Lizenzhinweis gern mit diesem Tool erstellen. Um ganz sicherzugehen, empfehlen wir Ihnen, die Lizenzpflichten anhand des Lizenztextes zu überprüfen. Der Lizenzhinweis ist zusätzlich an die Sprache des Nutzungskontextes anzupassen."


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T116022
Demo: https://tools.wmflabs.org/file-reuse-test/private-use-box/redesign/

Remarks:
 - defining the colour of links would be shared with https://github.com/wmde/Lizenzverweisgenerator/pull/143, so I haven't duplicated it here,
 - same as in https://github.com/wmde/Lizenzverweisgenerator/pull/143 links in the box open in the new window,
 - please comment if opening the additional information on private use should NOT be tracked (I assumed it should as it is already done with other pop-up boxes),
 - given the remark above, I haven't tested if this particular tracking works as I haven't set up the Piwik instance for AG yet. Verifying it would be great.