### PR TITLE
Change licences

### DIFF
--- a/redesign/js/app/LICENCES.js
+++ b/redesign/js/app/LICENCES.js
@@ -22,6 +22,7 @@ module.exports = [
 	new Licence( 'cc-by-sa-2.0-de', [ 'cc', 'cc2', 'cc2de' ], [ 'cc-by-sa-2.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ], 'CC BY-SA 2.0 DE', /^(Bild-)?CC-BY-SA(-|\/)2.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by-sa/2.0/de/legalcode/' ),
 	new Licence( 'cc-by-sa-2.0', [ 'cc', 'cc2' ], [ 'cc-by-sa-2.0-de', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ], 'CC BY-SA 2.0', /^(Bild-)?CC-BY-SA(-|\/)2.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by-sa/2.0/legalcode/' ),
 	new Licence( 'cc-by-sa-2.0-ported', [ 'cc', 'cc2', 'ported' ], [], 'CC BY-SA 2.0', /^(Bild-)?CC-BY-SA(-|\/)2.0-\w+$/i, 'http://creativecommons.org/licenses/by-sa/2.0/legalcode/' ),
+	new Licence( 'cc-by-sa-1.0', [ 'cc', 'cc1' ], [ 'cc-by-sa-2.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ], 'CC BY-SA 1.0', /^(Bild-)?CC-BY-SA(-|\/)1.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by-sa/1.0/legalcode/' ),
 
 	new Licence( 'cc-by-4.0', [ 'cc', 'cc4', 'ccby' ], [ 'cc-by-sa-4.0' ], 'CC BY 4.0', /^CC-BY-4.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/4.0/legalcode/' ),
 	new Licence( 'cc-by-3.0-de', [ 'cc', 'cc3', 'ccby' ], [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ], 'CC BY 3.0 DE', /^CC-BY(-|\/)3.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by/3.0/de/legalcode/' ),

--- a/redesign/js/app/LICENCES.js
+++ b/redesign/js/app/LICENCES.js
@@ -23,6 +23,7 @@ module.exports = [
 	new Licence( 'cc-by-sa-2.0', [ 'cc', 'cc2' ], [ 'cc-by-sa-2.0-de', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ], 'CC BY-SA 2.0', /^(Bild-)?CC-BY-SA(-|\/)2.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by-sa/2.0/legalcode/' ),
 	new Licence( 'cc-by-sa-2.0-ported', [ 'cc', 'cc2', 'ported' ], [], 'CC BY-SA 2.0', /^(Bild-)?CC-BY-SA(-|\/)2.0-\w+$/i, 'http://creativecommons.org/licenses/by-sa/2.0/legalcode/' ),
 	new Licence( 'cc-by-sa-1.0', [ 'cc', 'cc1' ], [ 'cc-by-sa-2.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ], 'CC BY-SA 1.0', /^(Bild-)?CC-BY-SA(-|\/)1.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by-sa/1.0/legalcode/' ),
+	new Licence( 'cc-by-sa-1.0-ported', [ 'cc', 'cc1', 'ported' ], [], 'CC BY-SA 1.0', /^(Bild-)?CC-BY-SA(-|\/)1.0-\w+$/i, 'http://creativecommons.org/licenses/by-sa/1.0/legalcode/' ),
 
 	new Licence( 'cc-by-4.0', [ 'cc', 'cc4', 'ccby' ], [ 'cc-by-sa-4.0' ], 'CC BY 4.0', /^CC-BY-4.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/4.0/legalcode/' ),
 	new Licence( 'cc-by-3.0-de', [ 'cc', 'cc3', 'ccby' ], [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ], 'CC BY 3.0 DE', /^CC-BY(-|\/)3.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by/3.0/de/legalcode/' ),

--- a/redesign/js/app/LICENCES.js
+++ b/redesign/js/app/LICENCES.js
@@ -13,32 +13,32 @@ var Licence = require( './Licence' );
  * @type {Licence[]} - sorted by restrictiveness
  */
 module.exports = [
-	new Licence( 'cc-by-sa-4.0', [ 'cc', 'cc4' ], 'CC BY-SA 4.0', /^(Bild-)?CC-BY-SA(-|\/)4.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by-sa/4.0/legalcode/' ),
-	new Licence( 'cc-by-sa-3.0-de', [ 'cc', 'cc3' ], 'CC BY-SA 3.0 DE', /^(Bild-)?CC-BY-SA(-|\/)3.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by-sa/3.0/de/legalcode/' ),
-	new Licence( 'cc-by-sa-3.0', [ 'cc', 'cc3' ], 'CC BY-SA 3.0', /^(Bild-)?CC-BY-SA(-|\/)3.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by-sa/3.0/legalcode/' ),
-	new Licence( 'cc-by-sa-3.0-ported', [ 'cc', 'cc3', 'ported' ], 'CC BY-SA 3.0', /^(Bild-)?CC-BY-SA(-|\/)3.0-\w+$/i, 'http://creativecommons.org/licenses/by-sa/3.0/legalcode/' ),
-	new Licence( 'cc-by-sa-2.5', [ 'cc', 'cc2.5' ], 'CC BY-SA 2.5', /^(Bild-)?CC-BY-SA(-|\/)2.5(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by-sa/2.5/legalcode/' ),
-	new Licence( 'cc-by-sa-2.5-ported', [ 'cc', 'cc2.5', 'ported' ], 'CC BY-SA 2.5', /^(Bild-)?CC-BY-SA(-|\/)2.5-\w+$/i, 'http://creativecommons.org/licenses/by-sa/2.5/legalcode/' ),
-	new Licence( 'cc-by-sa-2.0-de', [ 'cc', 'cc2', 'cc2de' ], 'CC BY-SA 2.0 DE', /^(Bild-)?CC-BY-SA(-|\/)2.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by-sa/2.0/de/legalcode/' ),
-	new Licence( 'cc-by-sa-2.0', [ 'cc', 'cc2' ], 'CC BY-SA 2.0', /^(Bild-)?CC-BY-SA(-|\/)2.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by-sa/2.0/legalcode/' ),
-	new Licence( 'cc-by-sa-2.0-ported', [ 'cc', 'cc2', 'ported' ], 'CC BY-SA 2.0', /^(Bild-)?CC-BY-SA(-|\/)2.0-\w+$/i, 'http://creativecommons.org/licenses/by-sa/2.0/legalcode/' ),
+	new Licence( 'cc-by-sa-4.0', [ 'cc', 'cc4' ], [], 'CC BY-SA 4.0', /^(Bild-)?CC-BY-SA(-|\/)4.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by-sa/4.0/legalcode/' ),
+	new Licence( 'cc-by-sa-3.0-de', [ 'cc', 'cc3' ], [ 'cc-by-sa-3.0', 'cc-by-sa-4.0' ], 'CC BY-SA 3.0 DE', /^(Bild-)?CC-BY-SA(-|\/)3.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by-sa/3.0/de/legalcode/' ),
+	new Licence( 'cc-by-sa-3.0', [ 'cc', 'cc3' ], [ 'cc-by-sa-3.0-de', 'cc-by-sa-4.0' ], 'CC BY-SA 3.0', /^(Bild-)?CC-BY-SA(-|\/)3.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by-sa/3.0/legalcode/' ),
+	new Licence( 'cc-by-sa-3.0-ported', [ 'cc', 'cc3', 'ported' ], [], 'CC BY-SA 3.0', /^(Bild-)?CC-BY-SA(-|\/)3.0-\w+$/i, 'http://creativecommons.org/licenses/by-sa/3.0/legalcode/' ),
+	new Licence( 'cc-by-sa-2.5', [ 'cc', 'cc2.5' ], [ 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ], 'CC BY-SA 2.5', /^(Bild-)?CC-BY-SA(-|\/)2.5(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by-sa/2.5/legalcode/' ),
+	new Licence( 'cc-by-sa-2.5-ported', [ 'cc', 'cc2.5', 'ported' ], [], 'CC BY-SA 2.5', /^(Bild-)?CC-BY-SA(-|\/)2.5-\w+$/i, 'http://creativecommons.org/licenses/by-sa/2.5/legalcode/' ),
+	new Licence( 'cc-by-sa-2.0-de', [ 'cc', 'cc2', 'cc2de' ], [ 'cc-by-sa-2.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ], 'CC BY-SA 2.0 DE', /^(Bild-)?CC-BY-SA(-|\/)2.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by-sa/2.0/de/legalcode/' ),
+	new Licence( 'cc-by-sa-2.0', [ 'cc', 'cc2' ], [ 'cc-by-sa-2.0-de', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ], 'CC BY-SA 2.0', /^(Bild-)?CC-BY-SA(-|\/)2.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by-sa/2.0/legalcode/' ),
+	new Licence( 'cc-by-sa-2.0-ported', [ 'cc', 'cc2', 'ported' ], [], 'CC BY-SA 2.0', /^(Bild-)?CC-BY-SA(-|\/)2.0-\w+$/i, 'http://creativecommons.org/licenses/by-sa/2.0/legalcode/' ),
 
-	new Licence( 'cc-by-4.0', [ 'cc', 'cc4', 'ccby' ], 'CC BY 4.0', /^CC-BY-4.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/4.0/legalcode/' ),
-	new Licence( 'cc-by-3.0-de', [ 'cc', 'cc3', 'ccby' ], 'CC BY 3.0 DE', /^CC-BY(-|\/)3.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by/3.0/de/legalcode/' ),
-	new Licence( 'cc-by-3.0', [ 'cc', 'cc3', 'ccby' ], 'CC BY 3.0', /^CC-BY-3.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/3.0/legalcode/' ),
-	new Licence( 'cc-by-3.0-ported', [ 'cc', 'cc3', 'ccby', 'ported' ], 'CC BY 3.0', /^CC-BY-3.0-\w+$/i, 'http://creativecommons.org/licenses/by/3.0/legalcode/' ),
-	new Licence( 'cc-by-2.5', [ 'cc', 'cc2.5', 'ccby' ], 'CC BY 2.5', /^CC-BY-2.5(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/2.5/legalcode/' ),
-	new Licence( 'cc-by-2.5-ported', [ 'cc', 'cc2.5', 'ccby', 'ported' ], 'CC BY 2.5', /^CC-BY-2.5-\w+$/i, 'http://creativecommons.org/licenses/by/2.5/legalcode/' ),
-	new Licence( 'cc-by-2.0-de', [ 'cc', 'cc2', 'cc2de', 'ccby' ], 'CC BY 2.0 DE', /^CC-BY(-|\/)2.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by/2.0/de/legalcode/' ),
-	new Licence( 'cc-by-2.0', [ 'cc', 'cc2', 'ccby' ], 'CC BY 2.0', /^CC-BY-2.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/2.0/legalcode/' ),
-	new Licence( 'cc-by-2.0-ported', [ 'cc', 'cc2', 'ccby', 'ported' ], 'CC BY 2.0', /^CC-BY-2.0-\w+$/i, 'http://creativecommons.org/licenses/by/2.0/legalcode/' ),
-	new Licence( 'cc-by-1.0', [ 'cc', 'cc1', 'ccby' ], 'CC BY 1.0', /^CC-BY-1.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/1.0/legalcode/' ),
-	new Licence( 'cc-by-1.0-ported', [ 'cc', 'cc1', 'ccby', 'ported' ], 'CC BY 1.0', /^CC-BY-1.0-\w+$/i, 'http://creativecommons.org/licenses/by/1.0/legalcode/' ),
+	new Licence( 'cc-by-4.0', [ 'cc', 'cc4', 'ccby' ], [ 'cc-by-sa-4.0' ], 'CC BY 4.0', /^CC-BY-4.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/4.0/legalcode/' ),
+	new Licence( 'cc-by-3.0-de', [ 'cc', 'cc3', 'ccby' ], [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ], 'CC BY 3.0 DE', /^CC-BY(-|\/)3.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by/3.0/de/legalcode/' ),
+	new Licence( 'cc-by-3.0', [ 'cc', 'cc3', 'ccby' ], [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ], 'CC BY 3.0', /^CC-BY-3.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/3.0/legalcode/' ),
+	new Licence( 'cc-by-3.0-ported', [ 'cc', 'cc3', 'ccby', 'ported' ], [], 'CC BY 3.0', /^CC-BY-3.0-\w+$/i, 'http://creativecommons.org/licenses/by/3.0/legalcode/' ),
+	new Licence( 'cc-by-2.5', [ 'cc', 'cc2.5', 'ccby' ], [ 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ], 'CC BY 2.5', /^CC-BY-2.5(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/2.5/legalcode/' ),
+	new Licence( 'cc-by-2.5-ported', [ 'cc', 'cc2.5', 'ccby', 'ported' ], [], 'CC BY 2.5', /^CC-BY-2.5-\w+$/i, 'http://creativecommons.org/licenses/by/2.5/legalcode/' ),
+	new Licence( 'cc-by-2.0-de', [ 'cc', 'cc2', 'cc2de', 'ccby' ], [ 'cc-by-2.0', 'cc-by-2.5', 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0' ], 'CC BY 2.0 DE', /^CC-BY(-|\/)2.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by/2.0/de/legalcode/' ),
+	new Licence( 'cc-by-2.0', [ 'cc', 'cc2', 'ccby' ], [ 'cc-by-2.0-de', 'cc-by-2.5', 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0' ], 'CC BY 2.0', /^CC-BY-2.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/2.0/legalcode/' ),
+	new Licence( 'cc-by-2.0-ported', [ 'cc', 'cc2', 'ccby', 'ported' ], [], 'CC BY 2.0', /^CC-BY-2.0-\w+$/i, 'http://creativecommons.org/licenses/by/2.0/legalcode/' ),
+	new Licence( 'cc-by-1.0', [ 'cc', 'cc1', 'ccby' ], [ 'cc-by-2.0-de', 'cc-by-2.0', 'cc-by-2.5', 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-1.0' ], 'CC BY 1.0', /^CC-BY-1.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/1.0/legalcode/' ),
+	new Licence( 'cc-by-1.0-ported', [ 'cc', 'cc1', 'ccby', 'ported' ], [], 'CC BY 1.0', /^CC-BY-1.0-\w+$/i, 'http://creativecommons.org/licenses/by/1.0/legalcode/' ),
 
-	new Licence( 'cc', [ 'unsupported' ], 'CC', /CC-BY/i ),
+	new Licence( 'cc', [ 'unsupported' ], [], 'CC', /CC-BY/i ),
 
-	new Licence( 'cc-zero', [ 'cc', 'cc0' ], 'CC0 1.0', /^(cc-zero|Bild-CC-0)/i, 'http://creativecommons.org/publicdomain/zero/1.0/legalcode/' ),
-	new Licence( 'PD', [ 'pd' ], 'Public Domain', /^(Bild-)?(PD|Public domain)\b/i ),
+	new Licence( 'cc-zero', [ 'cc', 'cc0' ], [], 'CC0 1.0', /^(cc-zero|Bild-CC-0)/i, 'http://creativecommons.org/publicdomain/zero/1.0/legalcode/' ),
+	new Licence( 'PD', [ 'pd' ], [], 'Public Domain', /^(Bild-)?(PD|Public domain)\b/i ),
 
-	new Licence( 'unknown', [ 'unknown' ], 'Unknown', '', '' )
+	new Licence( 'unknown', [ 'unknown' ], [], 'Unknown', '', '' )
 ];

--- a/redesign/js/app/LICENCES.js
+++ b/redesign/js/app/LICENCES.js
@@ -26,7 +26,7 @@ module.exports = [
 	new Licence( 'cc-by-sa-1.0-ported', [ 'cc', 'cc1', 'ported' ], [], 'CC BY-SA 1.0', /^(Bild-)?CC-BY-SA(-|\/)1.0-\w+$/i, 'http://creativecommons.org/licenses/by-sa/1.0/legalcode/' ),
 
 	new Licence( 'cc-by-4.0', [ 'cc', 'cc4', 'ccby' ], [ 'cc-by-sa-4.0' ], 'CC BY 4.0', /^CC-BY-4.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/4.0/legalcode/' ),
-	new Licence( 'cc-by-3.0-de', [ 'cc', 'cc3', 'ccby' ], [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ], 'CC BY 3.0 DE', /^CC-BY(-|\/)3.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by/3.0/de/legalcode/' ),
+	new Licence( 'cc-by-3.0-de', [ 'cc', 'cc3', 'ccby' ], [ 'cc-by-3.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ], 'CC BY 3.0 DE', /^CC-BY(-|\/)3.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by/3.0/de/legalcode/' ),
 	new Licence( 'cc-by-3.0', [ 'cc', 'cc3', 'ccby' ], [ 'cc-by-3.0-de', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ], 'CC BY 3.0', /^CC-BY-3.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/3.0/legalcode/' ),
 	new Licence( 'cc-by-3.0-ported', [ 'cc', 'cc3', 'ccby', 'ported' ], [], 'CC BY 3.0', /^CC-BY-3.0-\w+$/i, 'http://creativecommons.org/licenses/by/3.0/legalcode/' ),
 	new Licence( 'cc-by-2.5', [ 'cc', 'cc2.5', 'ccby' ], [ 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ], 'CC BY 2.5', /^CC-BY-2.5(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/2.5/legalcode/' ),

--- a/redesign/js/app/LICENCES.js
+++ b/redesign/js/app/LICENCES.js
@@ -27,7 +27,7 @@ module.exports = [
 
 	new Licence( 'cc-by-4.0', [ 'cc', 'cc4', 'ccby' ], [ 'cc-by-sa-4.0' ], 'CC BY 4.0', /^CC-BY-4.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/4.0/legalcode/' ),
 	new Licence( 'cc-by-3.0-de', [ 'cc', 'cc3', 'ccby' ], [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ], 'CC BY 3.0 DE', /^CC-BY(-|\/)3.0(-|\/)DE/i, 'http://creativecommons.org/licenses/by/3.0/de/legalcode/' ),
-	new Licence( 'cc-by-3.0', [ 'cc', 'cc3', 'ccby' ], [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ], 'CC BY 3.0', /^CC-BY-3.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/3.0/legalcode/' ),
+	new Licence( 'cc-by-3.0', [ 'cc', 'cc3', 'ccby' ], [ 'cc-by-3.0-de', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ], 'CC BY 3.0', /^CC-BY-3.0(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/3.0/legalcode/' ),
 	new Licence( 'cc-by-3.0-ported', [ 'cc', 'cc3', 'ccby', 'ported' ], [], 'CC BY 3.0', /^CC-BY-3.0-\w+$/i, 'http://creativecommons.org/licenses/by/3.0/legalcode/' ),
 	new Licence( 'cc-by-2.5', [ 'cc', 'cc2.5', 'ccby' ], [ 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ], 'CC BY 2.5', /^CC-BY-2.5(([^\-]+.+|-migrated)*)?$/i, 'http://creativecommons.org/licenses/by/2.5/legalcode/' ),
 	new Licence( 'cc-by-2.5-ported', [ 'cc', 'cc2.5', 'ccby', 'ported' ], [], 'CC BY 2.5', /^CC-BY-2.5-\w+$/i, 'http://creativecommons.org/licenses/by/2.5/legalcode/' ),

--- a/redesign/js/app/Licence.js
+++ b/redesign/js/app/Licence.js
@@ -185,6 +185,15 @@ $.extend( Licence.prototype, {
 	},
 
 	/**
+	 * Returns the id of the licence's unported equivalent e.g. 'cc-by-3.0' for 'cc-by-3.0-ported'
+	 *
+	 * @returns {string}
+	 */
+	getUnportedVersionId: function() {
+		return this.getId().slice( 0, -7 );
+	},
+
+	/**
 	 * Retrieves the licence text of a specific licence.
 	 *
 	 * @return {Object} jQuery Promise

--- a/redesign/js/app/Licence.js
+++ b/redesign/js/app/Licence.js
@@ -38,13 +38,14 @@ var $ = require( 'jquery' ),
  * @throws {Error} if no proper parameters are specified.
  * @throws {Error} when trying to instantiate an "abstract" licence with an additional regExp.
  */
-var Licence = function( id, groups, name, regExp, url, options ) {
-	if( !id || !groups || !name ) {
+var Licence = function( id, groups, compatibleLicences, name, regExp, url, options ) {
+	if( !id || !groups || !name || typeof compatibleLicences !== 'object' ) {
 		throw new Error( 'Improper specification of required parameters' );
 	}
 
 	this._id = id;
 	this._groups = groups;
+	this._compatibleLicences = compatibleLicences;
 
 	if( $.isPlainObject( regExp ) ) {
 		options = regExp;
@@ -90,6 +91,12 @@ $.extend( Licence.prototype, {
 	 * @type {string[]}
 	 */
 	_groups: null,
+
+	/**
+	 * Identifiers of compatible licences.
+	 * @type {string[]}
+	 */
+	_compatibleLicences: null,
 
 	/**
 	 * @type {Object}
@@ -150,6 +157,10 @@ $.extend( Licence.prototype, {
 			}
 		}
 		return false;
+	},
+
+	getCompatibleLicenceIds: function() {
+		return this._compatibleLicences;
 	},
 
 	/**

--- a/redesign/js/app/LicenceStep.js
+++ b/redesign/js/app/LicenceStep.js
@@ -8,6 +8,9 @@ var $ = require( 'jquery' ),
 
 var LicenceStep = function( licence ) {
 	this._name = 'licence';
+	if( licence.isInGroup( 'ported' ) ) {
+		licence = licences.getLicence( licence.getUnportedVersionId() );
+	}
 	this._view = new LicenceStepView( licence, licences.findCompatibilities( licence.getId() ) );
 };
 

--- a/redesign/js/app/LicenceStore.js
+++ b/redesign/js/app/LicenceStore.js
@@ -117,55 +117,16 @@ $.extend( LicenceStore.prototype, {
 	},
 
 	/**
-	 * Returns the licence's index or index+1 if it is a -de licence.
-	 * The +1 operation is necessary because -de licences are mutually compatible with their unported counterpart.
-	 * @param {string} licence - licence ID
-	 * @returns {int|null}
-	 */
-	_getLicenceRestrictivenessIndex: function( licence ) {
-		for( var i = 0; i < this._licences.length; i++ ) {
-			if( this._licences[ i ].getId() === licence ) {
-				return licence.slice( -3 ) === '-de' ? i + 1 : i;
-			}
-		}
-		return null;
-	},
-
-	/**
-	 * Returns licences with an index of `index` and lower
-	 * @param index
-	 * @returns {Licence[]}
-	 */
-	_getLicencesStartingAt: function( index ) {
-		var result = [];
-		for( var i = index; i >= 0; i-- ) {
-			result.push( this._licences[ i ] );
-		}
-
-		return result;
-	},
-
-	/**
-	 * Removes the licence with an ID of `id` and all ported licences
-	 * @param {Licence[]} licences
-	 * @param {string} id
-	 * @returns {Licence[]}
-	 */
-	_removeSameAndPorted: function( licences, id ) {
-		return licences.filter( function( licence ) {
-			return licence.getId() !== id && licence.getId().indexOf( '-ported' ) === -1;
-		} );
-	},
-
-	/**
 	 * Finds a list of compatible licences for a given licence ID
 	 * @param licence
 	 * @return {Licence[]}
 	 */
 	findCompatibilities: function( licence ) {
-		var index = this._getLicenceRestrictivenessIndex( licence );
+		var self = this;
 
-		return this._removeSameAndPorted( this._getLicencesStartingAt( index ), licence );
+		return this.getLicence( licence ).getCompatibleLicenceIds().map( function( id ) {
+			return self.getLicence( id );
+		} );
 	}
 } );
 

--- a/redesign/js/app/LicenceStore.js
+++ b/redesign/js/app/LicenceStore.js
@@ -9,10 +9,10 @@ var $ = require( 'jquery' ),
 	Licence = require( './Licence' );
 
 /**
- * Licence store storing an ordered list of licences.
+ * Licence store storing a list of licences.
  * @constructor
  *
- * @param {Licence} licences
+ * @param {Licence[]} licences
  */
 var LicenceStore = function( licences ) {
 	this._licences = [];

--- a/redesign/tests/app/AttributionDialogueView.tests.js
+++ b/redesign/tests/app/AttributionDialogueView.tests.js
@@ -131,8 +131,8 @@ QUnit.test( 'Licence Step', function( assert ) {
 		new AttributionDialogueView( new Asset( '', '', licences.getLicence( 'cc-by-3.0-de' ) ) )
 	);
 
-	assert.equal( dialogue.dom.find( 'input:checkbox' ).length, 5 ); // 4 compatible licences + the original licence
-	assert.equal( dialogue.dom.find( 'a[target="_blank"]' ).length, 5 );
+	assert.equal( dialogue.dom.find( 'input:checkbox' ).length, 4 ); // 4 compatible licences + the original licence
+	assert.equal( dialogue.dom.find( 'a[target="_blank"]' ).length, 4 );
 } );
 
 QUnit.test( 'Dialogue walkthrough', function( assert ) {

--- a/redesign/tests/app/AttributionDialogueView.tests.js
+++ b/redesign/tests/app/AttributionDialogueView.tests.js
@@ -131,8 +131,8 @@ QUnit.test( 'Licence Step', function( assert ) {
 		new AttributionDialogueView( new Asset( '', '', licences.getLicence( 'cc-by-3.0-de' ) ) )
 	);
 
-	assert.equal( dialogue.dom.find( 'input:checkbox' ).length, 9 ); // 8 compatible licences + the original licence
-	assert.equal( dialogue.dom.find( 'a[target="_blank"]' ).length, 9 );
+	assert.equal( dialogue.dom.find( 'input:checkbox' ).length, 5 ); // 4 compatible licences + the original licence
+	assert.equal( dialogue.dom.find( 'a[target="_blank"]' ).length, 5 );
 } );
 
 QUnit.test( 'Dialogue walkthrough', function( assert ) {
@@ -193,7 +193,7 @@ QUnit.test( 'Dialogue walkthrough', function( assert ) {
 	assert.equal( dialogue._dialogue.getData()[ 'editing' ][ 'edited' ], 'true' );
 	assert.equal( dialogue._dialogue.getData()[ 'change' ][ 'change' ], 'cropped' );
 	assert.equal( dialogue._dialogue.getData()[ 'creator' ][ 'name' ], 'Meh' );
-	assert.equal( dialogue._dialogue.getData()[ 'licence' ][ 'licence' ], 'cc-by-3.0-de' );
+	assert.equal( dialogue._dialogue.getData()[ 'licence' ][ 'licence' ], 'cc-by-3.0' );
 } );
 
 QUnit.test( 'show done after completing last step', function( assert ) {

--- a/redesign/tests/app/LicenceStore.tests.js
+++ b/redesign/tests/app/LicenceStore.tests.js
@@ -30,6 +30,10 @@ QUnit.test( 'detects CC BY SA 2.0', function( assert ) {
 	assert.equal( licences.detectLicence( 'Cc-by-sa-2.0' ).getName(), 'CC BY-SA 2.0' );
 } );
 
+QUnit.test( 'detects CC BY SA 1.0', function( assert ) {
+	assert.equal( licences.detectLicence( 'Cc-by-sa-1.0' ).getName(), 'CC BY-SA 1.0' );
+} );
+
 QUnit.test( 'detects ported CC BY 1.0', function( assert ) {
 	assert.equal( licences.detectLicence( 'Cc-by-1.0-nl' ).getId(), 'cc-by-1.0-ported' );
 } );
@@ -69,6 +73,7 @@ QUnit.test( 'compatible licences', function( assert ) {
 		'cc-by-sa-2.5': [ 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
 		'cc-by-sa-2.0': [ 'cc-by-sa-2.0-de', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
 		'cc-by-sa-2.0-de': [ 'cc-by-sa-2.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
+		'cc-by-sa-1.0': [ 'cc-by-sa-2.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
 		'cc-by-4.0': [ 'cc-by-sa-4.0' ],
 		'cc-by-3.0': [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ],
 		'cc-by-3.0-de': [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ],

--- a/redesign/tests/app/LicenceStore.tests.js
+++ b/redesign/tests/app/LicenceStore.tests.js
@@ -69,13 +69,13 @@ QUnit.test( 'compatible licences', function( assert ) {
 		'cc-by-sa-2.5': [ 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
 		'cc-by-sa-2.0': [ 'cc-by-sa-2.0-de', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
 		'cc-by-sa-2.0-de': [ 'cc-by-sa-2.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
-		'cc-by-4.0': [ 'cc-by-sa-2.0-de', 'cc-by-sa-2.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
-		'cc-by-3.0': [ 'cc-by-3.0-de', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
-		'cc-by-3.0-de': [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
-		'cc-by-2.5': [ 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
-		'cc-by-2.0': [ 'cc-by-2.0-de', 'cc-by-2.5', 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
-		'cc-by-2.0-de': [ 'cc-by-2.0', 'cc-by-2.5', 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
-		'cc-by-1.0': [ 'cc-by-2.0-de', 'cc-by-2.0', 'cc-by-2.5', 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ]
+		'cc-by-4.0': [ 'cc-by-sa-4.0' ],
+		'cc-by-3.0': [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ],
+		'cc-by-3.0-de': [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ],
+		'cc-by-2.5': [ 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
+		'cc-by-2.0': [ 'cc-by-2.0-de', 'cc-by-2.5', 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0' ],
+		'cc-by-2.0-de': [ 'cc-by-2.0', 'cc-by-2.5', 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0' ],
+		'cc-by-1.0': [ 'cc-by-2.0-de', 'cc-by-2.0', 'cc-by-2.5', 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-1.0' ]
 	};
 
 	$.each( compatibleLicences, function( input, compatibles ) {

--- a/redesign/tests/app/LicenceStore.tests.js
+++ b/redesign/tests/app/LicenceStore.tests.js
@@ -80,7 +80,7 @@ QUnit.test( 'compatible licences', function( assert ) {
 		'cc-by-sa-1.0': [ 'cc-by-sa-2.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
 		'cc-by-4.0': [ 'cc-by-sa-4.0' ],
 		'cc-by-3.0': [ 'cc-by-3.0-de', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ],
-		'cc-by-3.0-de': [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ],
+		'cc-by-3.0-de': [ 'cc-by-3.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ],
 		'cc-by-2.5': [ 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
 		'cc-by-2.0': [ 'cc-by-2.0-de', 'cc-by-2.5', 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0' ],
 		'cc-by-2.0-de': [ 'cc-by-2.0', 'cc-by-2.5', 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0' ],

--- a/redesign/tests/app/LicenceStore.tests.js
+++ b/redesign/tests/app/LicenceStore.tests.js
@@ -34,6 +34,10 @@ QUnit.test( 'detects CC BY SA 1.0', function( assert ) {
 	assert.equal( licences.detectLicence( 'Cc-by-sa-1.0' ).getName(), 'CC BY-SA 1.0' );
 } );
 
+QUnit.test( 'detects ported CC BY-SA 1.0', function( assert ) {
+	assert.equal( licences.detectLicence( 'Cc-by-sa-1.0-nl' ).getId(), 'cc-by-sa-1.0-ported' );
+} );
+
 QUnit.test( 'detects ported CC BY 1.0', function( assert ) {
 	assert.equal( licences.detectLicence( 'Cc-by-1.0-nl' ).getId(), 'cc-by-1.0-ported' );
 } );

--- a/redesign/tests/app/LicenceStore.tests.js
+++ b/redesign/tests/app/LicenceStore.tests.js
@@ -79,7 +79,7 @@ QUnit.test( 'compatible licences', function( assert ) {
 		'cc-by-sa-2.0-de': [ 'cc-by-sa-2.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
 		'cc-by-sa-1.0': [ 'cc-by-sa-2.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
 		'cc-by-4.0': [ 'cc-by-sa-4.0' ],
-		'cc-by-3.0': [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ],
+		'cc-by-3.0': [ 'cc-by-3.0-de', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ],
 		'cc-by-3.0-de': [ 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0' ],
 		'cc-by-2.5': [ 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.5', 'cc-by-sa-3.0-de', 'cc-by-sa-3.0', 'cc-by-sa-4.0' ],
 		'cc-by-2.0': [ 'cc-by-2.0-de', 'cc-by-2.5', 'cc-by-3.0-de', 'cc-by-3.0', 'cc-by-4.0', 'cc-by-sa-2.0-de', 'cc-by-sa-2.0' ],


### PR DESCRIPTION
This adds the CC BY-SA 1.0 licence and also changes the compatible licences according to the adjustments in the specification.
Task1: https://phabricator.wikimedia.org/T119373
Task2: https://phabricator.wikimedia.org/T118953

Demo: 
**Instructions for task 1**: Enter and submit `https://commons.wikimedia.org/wiki/File:%22Лунг%22_Заказник_ландшафтний1.JPG` (CC BY 1.0), click through to the licence step (make sure to click "Ja" in the editing step). There should now no longer be any SA licences other than the 1.0 in the list of compatible licences. The same goes for the other cases where things were changed!

**Instructions for task 2**: Enter and submit `https://commons.wikimedia.org/wiki/File:Cinnamomum_Verum_vs_Cinnamomum_Burmannii.jpg` (CC BY-SA 1.0). There should not be any error