### PR TITLE
Do not add closing X button to the ported license info box

### DIFF
--- a/redesign/js/app/templates/InfoBox.handlebars
+++ b/redesign/js/app/templates/InfoBox.handlebars
@@ -1,5 +1,7 @@
 <div class="info-box">
-	<button type="button" class="close close-info">&times;</button>
+	{{#unless noCloseButton}}
+		<button type="button" class="close close-info">&times;</button>
+	{{/unless}}
 
 	<div class="info-box-text">
 		{{{content}}}

--- a/redesign/js/app/views/InfoBoxView.js
+++ b/redesign/js/app/views/InfoBoxView.js
@@ -36,7 +36,7 @@ $.extend( InfoBoxView.prototype, {
 			return '';
 		}
 
-		var $box = $( infoBox( { content: this._text, buttons: this._buttons } ) ),
+		var $box = $( infoBox( { content: this._text, buttons: this._buttons, noCloseButton: this._name === 'ported-licence' } ) ),
 			self = this;
 
 		$box.find( '.close-info' ).click( function( e ) {


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T119627
Demo: https://tools.wmflabs.org/file-reuse-test/ported-no-close/redesign/

I've tested it with `https://commons.wikimedia.org/wiki/File:Timo-Juurikkala2004.jpg` licensed on the ported version of CC-BY-1.0 (first ported license from the list).

I'm not sure at what level not adding the close button should be actually done, so it might be that this first attempt is not the right one.