### PR TITLE
Adjust the size of images and text in the "How it works" screen to the size of the screen

### DIFF
--- a/redesign/css/main.css
+++ b/redesign/css/main.css
@@ -107,7 +107,13 @@ textarea, input, .form-control:focus, textarea:hover, input:hover, textarea:acti
 }
 
 .how-it-works-image {
-  width: 200px;
+  width: 90%;
+}
+
+@media (max-width : 992px) {
+  .how-it-works-screen .row-2 p {
+    font-size: 12pt;
+  }
 }
 
 .how-it-works-col-1 {


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T118954
Demo: https://tools.wmflabs.org/file-reuse-test/how-it-works-more-responsive/redesign/

I am not sure how big those icons should actually be on really big screens. Maybe even bigger than now.
Also made those images smaller on smaller screens, where the text could be a bit smaller (at least it looked like this for me when I made a window small).
Has this thing been designed by Mr. UX Expert?