### PR TITLE
Progress bar back

### DIFF
--- a/redesign/css/main.css
+++ b/redesign/css/main.css
@@ -372,7 +372,7 @@ a:hover {
   background: #97b314;
   border-radius: 2px;
   padding: 10px;
-  margin: 0 25px 0 200px;
+  margin: 0 25px 0 210px;
 }
 .dialogue-bubble .bubble-text {
   color: #fff;
@@ -607,7 +607,7 @@ a:hover {
 
 .ag-progress-bar {
   float: left;
-  width: 180px;
+  width: 200px;
   padding: 10px;
 }
 .ag-progress-bar li {

--- a/redesign/js/app/AttributionDialogue.js
+++ b/redesign/js/app/AttributionDialogue.js
@@ -24,9 +24,20 @@ $.extend( AttributionDialogue.prototype, Dialogue.prototype, {
 		return this._asset;
 	},
 
+	setStep: function( n ) {
+		Dialogue.prototype.setStep.call( this, n );
+		if( this._hasAuthor() && n < 4 || n < 3 ) {
+			this._removeEditingSteps();
+		}
+	},
+
+	_hasAuthor: function() {
+		return this._asset.getAuthors().length === 0;
+	},
+
 	init: function() {
 		this.addStep( new DialogueStep( 'typeOfUse', require( './templates/TypeOfUseStep.handlebars' ) ) );
-		if( this._asset.getAuthors().length === 0 ) {
+		if( this._hasAuthor() ) {
 			this.addStep( new DialogueStep( 'author', require( './templates/AuthorStep.handlebars' ) ) );
 		}
 		this.addStep( new DialogueStep( 'compilation', require( './templates/CompilationStep.handlebars' ) ) );
@@ -39,6 +50,14 @@ $.extend( AttributionDialogue.prototype, Dialogue.prototype, {
 		var data = step.getData();
 		if( step.getName() === 'editing' && data[ 'edited' ] === 'true' ) {
 			this._addEditingSteps();
+		}
+	},
+
+	_removeEditingSteps: function() {
+		if( this._steps.length > 4 ) {
+			this._steps.pop();
+			this._steps.pop();
+			this._steps.pop();
 		}
 	},
 

--- a/redesign/js/app/Dialogue.js
+++ b/redesign/js/app/Dialogue.js
@@ -70,6 +70,13 @@ $.extend( Dialogue.prototype, {
 		return this._steps[ this._currentStep ];
 	},
 
+	/**
+	 * @returns {int}
+	 */
+	currentStepIndex: function() {
+		return this._currentStep;
+	},
+
 	getSteps: function() {
 		return this._steps;
 	}

--- a/redesign/js/app/views/AttributionDialogueView.js
+++ b/redesign/js/app/views/AttributionDialogueView.js
@@ -12,7 +12,7 @@ var AttributionDialogueView = function( asset ) {
 	this._dialogue = new AttributionDialogue( asset );
 	this._dialogue.init();
 
-	this._progressBar = new ProgressBarView( this._dialogue );
+	this._progressBar = new ProgressBarView( this._dialogue, this );
 
 	this._privateUseBox = new InfoBoxView(
 		'private-use',
@@ -48,6 +48,11 @@ $.extend( AttributionDialogueView.prototype, {
 	 * @type {ProgressBarView}
 	 */
 	_progressBar: null,
+
+	/**
+	 * @type {jQuery}
+	 */
+	_$html: $( '<div/>' ),
 
 	/**
 	 * Turns a $form.serializeArray return value into an object
@@ -110,6 +115,10 @@ $.extend( AttributionDialogueView.prototype, {
 		$bubble.css( 'min-height', ( 25 + 18 + progressIndex * 23 ) + 'px' );
 	},
 
+	updateContent: function() {
+		this.render( this._$html );
+	},
+
 	/**
 	 * @param {jQuery} $dialogue
 	 */
@@ -117,6 +126,8 @@ $.extend( AttributionDialogueView.prototype, {
 		var $content = this._nextStepOrDone(),
 			self = this,
 			$infoBox = $( '#info-box' );
+
+		this._$html = $dialogue;
 
 		$infoBox.html( this._privateUseBox.render() );
 		if( this._dialogue.getAsset().getLicence().isInGroup( 'ported' ) ) {

--- a/redesign/js/app/views/ProgressBarView.js
+++ b/redesign/js/app/views/ProgressBarView.js
@@ -6,6 +6,7 @@ var $ = require( 'jquery' ),
 var ProgressBarView = function( dialogue, dialogueView ) {
 	this._dialogue = dialogue;
 	this._dialogueView = dialogueView;
+	this._initialized = false;
 };
 
 $.extend( ProgressBarView.prototype, {
@@ -18,6 +19,11 @@ $.extend( ProgressBarView.prototype, {
 	 * @type {AttributionDialogueView}
 	 */
 	_dialogueView: null,
+
+	/**
+	 * @type {boolean}
+	 */
+	_initialized: false,
 
 	/**
 	 * @param {int} n
@@ -59,6 +65,17 @@ $.extend( ProgressBarView.prototype, {
 			self._backToStep( $html.find( 'li a' ).index( $( this ) ) );
 			e.preventDefault();
 		} );
+
+		if( window.history && this._dialogue.currentStepIndex() > 0 ) {
+			window.history.pushState( 'step-back', '', '' );
+
+			if( !this._initialized ) {
+				this._initialized = true;
+				$( window ).on( 'popstate', function() {
+					self._backToStep( self._dialogue.currentStepIndex() - 1 );
+				} );
+			}
+		}
 
 		return $html;
 	}

--- a/redesign/js/app/views/ProgressBarView.js
+++ b/redesign/js/app/views/ProgressBarView.js
@@ -18,7 +18,9 @@ $.extend( ProgressBarView.prototype, {
 	 * @private
 	 */
 	_backToStep: function( n ) {
-		this._dialogue.setStep( n );
+		if( n < this._dialogue.currentStepIndex() ) {
+			this._dialogue.setStep( n );
+		}
 	},
 
 	render: function() {

--- a/redesign/js/app/views/ProgressBarView.js
+++ b/redesign/js/app/views/ProgressBarView.js
@@ -3,8 +3,9 @@
 var $ = require( 'jquery' ),
 	template = require( '../templates/ProgressBar.handlebars' );
 
-var ProgressBarView = function( dialogue ) {
+var ProgressBarView = function( dialogue, dialogueView ) {
 	this._dialogue = dialogue;
+	this._dialogueView = dialogueView;
 };
 
 $.extend( ProgressBarView.prototype, {
@@ -14,13 +15,21 @@ $.extend( ProgressBarView.prototype, {
 	_dialogue: null,
 
 	/**
+	 * @type {AttributionDialogueView}
+	 */
+	_dialogueView: null,
+
+	/**
 	 * @param {int} n
 	 * @private
 	 */
 	_backToStep: function( n ) {
-		if( n < this._dialogue.currentStepIndex() ) {
-			this._dialogue.setStep( n );
+		if( n >= this._dialogue.currentStepIndex() ) {
+			return;
 		}
+
+		this._dialogue.setStep( n );
+		this._dialogueView.updateContent();
 	},
 
 	render: function() {

--- a/redesign/js/app/views/ProgressBarView.js
+++ b/redesign/js/app/views/ProgressBarView.js
@@ -13,6 +13,14 @@ $.extend( ProgressBarView.prototype, {
 	 */
 	_dialogue: null,
 
+	/**
+	 * @param {int} n
+	 * @private
+	 */
+	_backToStep: function( n ) {
+		this._dialogue.setStep( n );
+	},
+
 	render: function() {
 		var steps = this._dialogue.getSteps()
 			.concat( [ {
@@ -33,7 +41,13 @@ $.extend( ProgressBarView.prototype, {
 						isCompleted: i < activeStep
 					};
 				} )
-			} ) );
+			} ) ),
+			self = this;
+
+		$html.find( 'li a' ).click( function( e ) {
+			self._backToStep( $html.find( 'li a' ).index( $( this ) ) );
+			e.preventDefault();
+		} );
 
 		return $html;
 	}

--- a/redesign/js/app/views/ProgressBarView.js
+++ b/redesign/js/app/views/ProgressBarView.js
@@ -25,6 +25,13 @@ $.extend( ProgressBarView.prototype, {
 	 */
 	_initialized: false,
 
+	_backBuffer: false,
+
+	_setBackBuffer: function() {
+		this._backBuffer = true;
+		window.history.pushState( 'step-back', '', '' );
+	},
+
 	/**
 	 * @param {int} n
 	 * @private
@@ -67,11 +74,15 @@ $.extend( ProgressBarView.prototype, {
 		} );
 
 		if( window.history && this._dialogue.currentStepIndex() > 0 ) {
-			window.history.pushState( 'step-back', '', '' );
+			if( !this._backBuffer ) {
+				this._setBackBuffer();
+			}
 
 			if( !this._initialized ) {
 				this._initialized = true;
+
 				$( window ).on( 'popstate', function() {
+					self._backBuffer = false;
 					self._backToStep( self._dialogue.currentStepIndex() - 1 );
 				} );
 			}

--- a/redesign/js/app/views/ProgressBarView.js
+++ b/redesign/js/app/views/ProgressBarView.js
@@ -37,7 +37,7 @@ $.extend( ProgressBarView.prototype, {
 	 * @private
 	 */
 	_backToStep: function( n ) {
-		if( n >= this._dialogue.currentStepIndex() ) {
+		if( n < 0 || n >= this._dialogue.currentStepIndex() ) {
 			return;
 		}
 

--- a/redesign/tests/TestHelpers.js
+++ b/redesign/tests/TestHelpers.js
@@ -3,6 +3,7 @@
 var LicenceStore = require( '../js/app/LicenceStore' ),
 	Asset = require( '../js/app/Asset' ),
 	AttributionDialogue = require( '../js/app/AttributionDialogue' ),
+	AttributionDialogueView = require( '../js/app/views/AttributionDialogueView' ),
 	licences = new LicenceStore( require( '../js/app/LICENCES' ) );
 
 var TestHelpers = {
@@ -11,6 +12,9 @@ var TestHelpers = {
 		dialogue.init();
 
 		return dialogue;
+	},
+	newDefaultAttributionDialogueView: function() {
+		return new AttributionDialogueView( new Asset( '', '', licences.getLicence( 'cc' ), null, [] ) );
 	}
 };
 

--- a/redesign/tests/app/AttributionDialogueView.tests.js
+++ b/redesign/tests/app/AttributionDialogueView.tests.js
@@ -8,13 +8,10 @@ var $ = require( 'jquery' ),
 	Asset = require( '../../js/app/Asset' ),
 	DialogueEvaluation = require( '../../js/app/DialogueEvaluation' ),
 	LicenceStore = require( '../../js/app/LicenceStore' ),
-	licences = new LicenceStore( require( '../../js/app/LICENCES' ) );
+	licences = new LicenceStore( require( '../../js/app/LICENCES' ) ),
+	Helpers = require( '../TestHelpers' );
 
 $.fx.off = true;
-
-function newDefaultAttributionDialogueView() {
-	return new AttributionDialogueView( new Asset( '', '', licences.getLicence( 'cc' ), null, [] ) );
-}
 
 function dialogueContains( $dialogue, message ) {
 	return $dialogue.text().indexOf( Messages.t( message ) ) > -1;
@@ -22,21 +19,21 @@ function dialogueContains( $dialogue, message ) {
 
 QUnit.test( 'render should show the first step', function( assert ) {
 	var $dialogue = $( '<div/>' );
-	newDefaultAttributionDialogueView().render( $dialogue );
+	Helpers.newDefaultAttributionDialogueView().render( $dialogue );
 
 	assert.ok( dialogueContains( $dialogue, 'dialogue.type-of-use-headline' ) );
 } );
 
 QUnit.test( 'first step has two checkboxes', function( assert ) {
 	var $dialogue = $( '<div/>' );
-	newDefaultAttributionDialogueView().render( $dialogue );
+	Helpers.newDefaultAttributionDialogueView().render( $dialogue );
 
 	assert.equal( $dialogue.find( 'input[type="checkbox"]' ).length, 2 );
 } );
 
 function renderDialogueAtStep( n, dialogue ) {
 	var $dialogue = $( '<div/>' ),
-		dialogue = dialogue || newDefaultAttributionDialogueView();
+		dialogue = dialogue || Helpers.newDefaultAttributionDialogueView();
 	if( n > 3 ) {
 		dialogue._dialogue._addEditingSteps();
 	}
@@ -48,7 +45,7 @@ function renderDialogueAtStep( n, dialogue ) {
 
 QUnit.test( 'clicking a checkbox on first step submits and saves data', function( assert ) {
 	var $dialogue = $( '<div/>' ),
-		dialogue = newDefaultAttributionDialogueView();
+		dialogue = Helpers.newDefaultAttributionDialogueView();
 	dialogue.render( $dialogue );
 
 	$dialogue.find( 'input:checkbox' )[ 0 ].click();
@@ -57,7 +54,7 @@ QUnit.test( 'clicking a checkbox on first step submits and saves data', function
 
 QUnit.test( 'submitting the form should renders second step', function( assert ) {
 	var $dialogue = $( '<div/>' );
-	newDefaultAttributionDialogueView().render( $dialogue );
+	Helpers.newDefaultAttributionDialogueView().render( $dialogue );
 
 	$dialogue.find( 'input[type="checkbox"]' )[ 0 ].click();
 	assert.ok( dialogueContains( $dialogue, 'dialogue.author-headline' ) );

--- a/redesign/tests/app/ProgressBarView.tests.js
+++ b/redesign/tests/app/ProgressBarView.tests.js
@@ -57,7 +57,7 @@ QUnit.test( 'should mark step < current step as completed and current step as ac
 
 QUnit.test( 'should mark all steps completed when the attribution is shown', function( assert ) {
 	var dialogue = Helpers.newDefaultAttributionDialogue(),
-			pb = new ProgressBarView( dialogue );
+		pb = new ProgressBarView( dialogue );
 	dialogue.currentStep().complete( {} );
 	dialogue.currentStep().complete( {} );
 	dialogue.currentStep().complete( {} );
@@ -65,4 +65,14 @@ QUnit.test( 'should mark all steps completed when the attribution is shown', fun
 
 	assert.equal( pb.render().find( 'li.active' ).length, 1 );
 	assert.equal( pb.render().find( 'li.completed' ).length, 4 );
+} );
+
+QUnit.test( 'go back using by clicking on a progress bar item', function( assert ) {
+	var dialogue = Helpers.newDefaultAttributionDialogue(),
+		pb = new ProgressBarView( dialogue ),
+		initialStep = dialogue.currentStep();
+
+	dialogue.currentStep().complete( {} );
+	pb.render().find( 'li a' )[ 0 ].click();
+	assert.equal( dialogue.currentStep(), initialStep );
 } );

--- a/redesign/tests/app/ProgressBarView.tests.js
+++ b/redesign/tests/app/ProgressBarView.tests.js
@@ -68,8 +68,9 @@ QUnit.test( 'should mark all steps completed when the attribution is shown', fun
 } );
 
 QUnit.test( 'go back using by clicking on a progress bar item', function( assert ) {
-	var dialogue = Helpers.newDefaultAttributionDialogue(),
-		pb = new ProgressBarView( dialogue ),
+	var dialogueView = Helpers.newDefaultAttributionDialogueView(),
+		dialogue = dialogueView._dialogue,
+		pb = new ProgressBarView( dialogue, dialogueView ),
 		initialStep = dialogue.currentStep();
 
 	dialogue.currentStep().complete( {} );
@@ -78,9 +79,10 @@ QUnit.test( 'go back using by clicking on a progress bar item', function( assert
 } );
 
 QUnit.test( 'going to steps that were not previously completed should not be possible', function( assert ) {
-	var dialogue = Helpers.newDefaultAttributionDialogue(),
-			pb = new ProgressBarView( dialogue ),
-			initialStep = dialogue.currentStep();
+	var dialogueView = Helpers.newDefaultAttributionDialogueView(),
+		dialogue = dialogueView._dialogue,
+		pb = new ProgressBarView( dialogue, dialogueView ),
+		initialStep = dialogue.currentStep();
 
 	pb.render().find( 'li a' )[ 2 ].click();
 	assert.equal( dialogue.currentStep(), initialStep );

--- a/redesign/tests/app/ProgressBarView.tests.js
+++ b/redesign/tests/app/ProgressBarView.tests.js
@@ -76,3 +76,12 @@ QUnit.test( 'go back using by clicking on a progress bar item', function( assert
 	pb.render().find( 'li a' )[ 0 ].click();
 	assert.equal( dialogue.currentStep(), initialStep );
 } );
+
+QUnit.test( 'going to steps that were not previously completed should not be possible', function( assert ) {
+	var dialogue = Helpers.newDefaultAttributionDialogue(),
+			pb = new ProgressBarView( dialogue ),
+			initialStep = dialogue.currentStep();
+
+	pb.render().find( 'li a' )[ 2 ].click();
+	assert.equal( dialogue.currentStep(), initialStep );
+} );

--- a/redesign/tests/app/ProgressBarView.tests.js
+++ b/redesign/tests/app/ProgressBarView.tests.js
@@ -87,3 +87,18 @@ QUnit.test( 'going to steps that were not previously completed should not be pos
 	pb.render().find( 'li a' )[ 2 ].click();
 	assert.equal( dialogue.currentStep(), initialStep );
 } );
+
+QUnit.test( 'should remove 3 editing substeps when going back further than editing', function( assert ) {
+	var dialogueView = Helpers.newDefaultAttributionDialogueView(),
+		dialogue = dialogueView._dialogue,
+		pb = new ProgressBarView( dialogue, dialogueView );
+
+	dialogue.currentStep().complete( {} );
+	dialogue.currentStep().complete( {} );
+	dialogue.currentStep().complete( {} );
+	dialogue.currentStep().complete( { edited: 'true' } );
+
+	assert.equal( dialogue.getSteps().length, 7 );
+	pb.render().find( 'li a' )[ 2 ].click();
+	assert.equal( dialogue.getSteps().length, 4 );
+} );


### PR DESCRIPTION
! Don't merge yet !

Task: https://phabricator.wikimedia.org/T116160
Demo: http://tools.wmflabs.org/file-reuse-test/progress_bar_back/redesign/

Going back by clicking progress bar items should work correctly with this patch.

The browser back functionality is where it gets a little bit tricky and I'm not sure my approach is going in the right direction. The way it is implemented here already sort of works but there are some ugly parts e.g. the forward button breaks everything and I'm pretty sure I'm pushing too many things onto the history.
Hoping to get insights from experienced browser history experts ... @wmde-manicki!? :D