### PR TITLE
Open author links in new window

### DIFF
--- a/redesign/js/app/DialogueEvaluation.js
+++ b/redesign/js/app/DialogueEvaluation.js
@@ -49,13 +49,24 @@ $.extend( DialogueEvaluation.prototype, {
 	},
 
 	_getHtmlAuthor: function() {
+		var self = this;
 		if( this._unknownAuthor() ) {
 			return this._unknownAuthorName();
 		}
 
 		return this._asset.getAuthors().map( function( author ) {
-			return typeof author === 'string' ? author : $( '<div/>' ).append( author.getHtml() ).html();
+			return typeof author === 'string' ? author : self._getAuthorWithLink( author );
 		} ).join( ', ' );
+	},
+
+	_getAuthorWithLink: function( $author ) {
+		var self = this,
+			$container = $( '<div/>' ).append( $author.getHtml() );
+		$container.find( 'a' ).each( function() {
+			var $link = $( this );
+			$( this ).replaceWith( self._makeLink( $link.attr( 'href' ), $link.text() ) );
+		} );
+		return $container.html();
 	},
 
 	_makeLink: function( target, text ) {

--- a/redesign/tests/app/DialogueEvaluation.tests.js
+++ b/redesign/tests/app/DialogueEvaluation.tests.js
@@ -87,9 +87,10 @@ QUnit.test( 'attribution contains editing information if it was edited', functio
 } );
 
 QUnit.test( 'online attribution contains author\'s html', function( assert ) {
-	var authorHtml = '<a href="#meh">Meh</a>',
-		evaluation = newEvaluation( { authors: [ new Author( $( authorHtml ) ) ] } );
-	assert.ok( attributionContains( evaluation, authorHtml ) );
+	var authorUrl = 'https://commons.wikimedia.org/wiki/User:Foo',
+		author = 'Foo',
+		evaluation = newEvaluation( { authors: [ new Author( $( '<a href="' + authorUrl + '">' + author + '</a>' ) ) ] } );
+	assert.ok( attributionContains( evaluation, '<a href="' + authorUrl + '" target="_blank">' + author + '</a>' ) );
 } );
 
 QUnit.test( 'online attribution contains link to asset from title', function( assert ) {


### PR DESCRIPTION
Demo: https://tools.wmflabs.org/file-reuse-test/author-links-target/redesign

Noticed that author links in attribution don't get `target` attribute while licence and title links do. Adding this for sake of consistency.

Changed the name of the test author as there seems to be some Commons user called "Meh" already.