### PR TITLE
Show the licence name in the link to the full text of the licence

### DIFF
--- a/redesign/js/app/views/DialogueEvaluationView.js
+++ b/redesign/js/app/views/DialogueEvaluationView.js
@@ -67,7 +67,8 @@ $.extend( DialogueEvaluationView.prototype, {
 		$( '<div class="licence-link"/>' )
 			.append( buttonTemplate( {
 				content: '<img class="cc-logo" src="images/cc.svg">'
-				+ Messages.t( 'evaluation.show-licence-text' ),
+				+ Messages.t( 'evaluation.show-licence-text' )
+				+ ' (' + this._evaluation.getAttributionLicence().getName() + ')',
 				target: this._evaluation.getAttributionLicence().getUrl()
 			} ) )
 			.appendTo( $html );


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T118743 (2nd part)
Demo: https://tools.wmflabs.org/file-reuse-test/licence-name-in-link/redesign/