### PR TITLE
Do not include <a> tags in the "plain text attribution"

### DIFF
--- a/redesign/js/app/DialogueEvaluation.js
+++ b/redesign/js/app/DialogueEvaluation.js
@@ -102,7 +102,7 @@ $.extend( DialogueEvaluation.prototype, {
 		var attribution = this._getAuthor() + ' '
 			+ '(' + this._asset.getUrl() + '), ';
 		if( !this._asset.getLicence().isInGroup( 'cc4' ) ) {
-			attribution += this._asset.getTitle() + ', ';
+			attribution += '„' + this._asset.getTitle() + '“' + ', ';
 		}
 		attribution += this._getEditingAttribution()
 			+ this.getAttributionLicence().getUrl();
@@ -118,10 +118,10 @@ $.extend( DialogueEvaluation.prototype, {
 
 	_getAttributionAsTextWithLinks: function() {
 		return this._getAuthor() + ' '
-			+ '(' + this._makeLink( this._asset.getUrl(), this._asset.getUrl() ) + '), '
+			+ '(' + this._asset.getUrl() + '), '
 			+ '„' + this._asset.getTitle() + '“' + ', '
 			+ this._getEditingAttribution()
-			+ this._makeLink( this.getAttributionLicence().getUrl(), this.getAttributionLicence().getUrl() );
+			+ this.getAttributionLicence().getUrl();
 	},
 
 	getAttribution: function() {
@@ -132,8 +132,8 @@ $.extend( DialogueEvaluation.prototype, {
 		return this._getHtmlAttribution();
 	},
 
-	getUnformattedAttribution: function() {
-		if( this._getResult( 'typeOfUse', 'type' ) === 'print' ) {
+	getPlainTextAttribution: function() {
+		if( this._getResult( 'typeOfUse', 'type' ) === 'print' || !this._asset.getLicence().isInGroup( 'cc4' ) ) {
 			return this._getPrintAttribution();
 		}
 		return this._getAttributionAsTextWithLinks();

--- a/redesign/js/app/templates/Attribution.handlebars
+++ b/redesign/js/app/templates/Attribution.handlebars
@@ -5,7 +5,7 @@
 			{{{attribution}}}
 		</div>
 		<div id="plain-text-attribution" class="display-none">
-			{{{unformattedAttribution}}}
+			{{{plainTextAttribution}}}
 		</div>
 		<div id="escaped-attribution" class="display-none">
 			{{attribution}}

--- a/redesign/js/app/views/DialogueEvaluationView.js
+++ b/redesign/js/app/views/DialogueEvaluationView.js
@@ -54,7 +54,7 @@ $.extend( DialogueEvaluationView.prototype, {
 
 		$html.append( attributionTemplate( {
 			attribution: this._evaluation.getAttribution(),
-			unformattedAttribution: this._evaluation.getUnformattedAttribution(),
+			plainTextAttribution: this._evaluation.getPlainTextAttribution(),
 			isPrint: this._evaluation.isPrint()
 		} ) );
 		$html.append( dosAndDontsTemplate( {

--- a/redesign/tests/app/DialogueEvaluation.tests.js
+++ b/redesign/tests/app/DialogueEvaluation.tests.js
@@ -149,7 +149,7 @@ QUnit.test( 'online attribution shows the author the user entered', function( as
 	assert.ok( attributionContains( evaluation, 'Meh' ) );
 } );
 
-QUnit.test( 'unformatted attribution for online usage is generated correctly', function( assert ) {
+QUnit.test( 'plain text attribution for online usage is generated correctly', function( assert ) {
 	var evaluation = newEvaluation(
 		{
 			authors: [ new Author( $( '<a href="https://commons.wikimedia.org/wiki/User:Foo">Foo</a>' ) ) ],
@@ -159,11 +159,11 @@ QUnit.test( 'unformatted attribution for online usage is generated correctly', f
 		},
 		{ 'typeOfUse': { type: 'online' } }
 	),
-		expectedAttribution = 'Foo (<a href="https://commons.wikimedia.org/wiki/File:Baz.jpg" target="_blank">https://commons.wikimedia.org/wiki/File:Baz.jpg</a>), „Bar“, <a href="https://creativecommons.org/licenses/by/3.0/legalcode" target="_blank">https://creativecommons.org/licenses/by/3.0/legalcode</a>';
-	assert.equal( evaluation.getUnformattedAttribution(), expectedAttribution );
+		expectedAttribution = 'Foo (https://commons.wikimedia.org/wiki/File:Baz.jpg), „Bar“, https://creativecommons.org/licenses/by/3.0/legalcode';
+	assert.equal( evaluation.getPlainTextAttribution(), expectedAttribution );
 } );
 
-QUnit.test( 'unformatted attribution for print usage is same as the normal attribution', function( assert ) {
+QUnit.test( 'plain text attribution for print usage is the same as the normal attribution', function( assert ) {
 	var evaluation = newEvaluation(
 		{
 			authors: [ new Author( $( '<a href="https://commons.wikimedia.org/wiki/User:Foo">Foo</a>' ) ) ],
@@ -173,7 +173,7 @@ QUnit.test( 'unformatted attribution for print usage is same as the normal attri
 		},
 		{ 'typeOfUse': { type: 'print' } }
 	);
-	assert.equal( evaluation.getUnformattedAttribution(), evaluation.getAttribution() );
+	assert.equal( evaluation.getPlainTextAttribution(), evaluation.getAttribution() );
 } );
 
 QUnit.test( 'has type of use information in the DOs section', function( assert ) {


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T119065
Demo: https://tools.wmflabs.org/file-reuse-test/plain-plain-text-attribution/redesign/

This remove not wanted hyperlinks from plan text attribution (which is now really a plain text).
This also adds quote marks to print attribution. I could leave it out if this is not intended but e.g. old version had those.