### PR TITLE
Use default change description of no description of edit has been pro…

### DIFF
--- a/redesign/js/app/DialogueEvaluation.js
+++ b/redesign/js/app/DialogueEvaluation.js
@@ -88,14 +88,19 @@ $.extend( DialogueEvaluation.prototype, {
 	},
 
 	_getEditingAttribution: function() {
+		var change, creator, attribution;
 		if( this._getResult( 'editing', 'edited' ) !== 'true' ) {
 			return '';
 		}
 
-		return this._getResult( 'change', 'change' )
-			+ ' ' + Messages.t( 'evaluation.by' )
-			+ ' ' + this._getResult( 'creator', 'name' )
-			+ ', ';
+		change = this._getResult( 'change', 'change' );
+		creator = this._getResult( 'creator', 'name' );
+		attribution = change || Messages.t( 'evaluation.edited' );
+		if( creator ) {
+			attribution += ' ' + Messages.t( 'evaluation.by' ) + ' ' + creator;
+		}
+		attribution += ', ';
+		return attribution;
 	},
 
 	_getPrintAttribution: function() {

--- a/redesign/js/i18n.json
+++ b/redesign/js/i18n.json
@@ -58,6 +58,7 @@
     },
     "evaluation": {
       "by": "von",
+      "edited": "bearbeitet",
       "done-text": "Sie haben alle Fragen beantwortet und können den Lizenzhinweis jetzt nutzen.",
       "your-attribution": "Ihr Lizenzhinweis",
       "copy": "Kopieren",

--- a/redesign/tests/app/DialogueEvaluation.tests.js
+++ b/redesign/tests/app/DialogueEvaluation.tests.js
@@ -98,6 +98,52 @@ QUnit.test( 'attribution contains editing information if it was edited', functio
 	assert.ok( attributionContains( evaluation, 'zugeschnitten von Meh, ' + licence.getUrl() ) );
 } );
 
+QUnit.test( 'attribution contains default change name if asset was edited but no change description has been provided', function( assert ) {
+	var licence = licences.getLicence( 'cc-by-3.0' ),
+		evaluation = newEvaluation(
+			{},
+			{
+				'typeOfUse': { type: 'print' },
+				editing: { edited: 'true' },
+				licence: { licence: licence.getId() },
+				creator: { name: 'Meh' }
+			}
+		);
+
+	assert.ok( attributionContains( evaluation, Messages.t( 'evaluation.edited' ) + ' ' + Messages.t( 'evaluation.by' ) + ' Meh, ' + licence.getUrl() ) );
+} );
+
+QUnit.test( 'attribution contains only change name if asset was edited but maker of changes has not been provided', function( assert ) {
+	var licence = licences.getLicence( 'cc-by-3.0' ),
+		evaluation = newEvaluation(
+			{},
+			{
+				'typeOfUse': { type: 'print' },
+				editing: { edited: 'true' },
+				licence: { licence: licence.getId() },
+				change: { change: 'zugeschnitten' }
+			}
+		);
+
+	assert.ok( attributionContains( evaluation, 'zugeschnitten, ' + licence.getUrl() ) );
+	assert.notOk( attributionContains( evaluation, ' ' + Messages.t( 'evaluation.by' ) + ' ' ) );
+} );
+
+QUnit.test( 'attribution contains only change name if asset was edited but no change description nor author of changes have been provided', function( assert ) {
+	var licence = licences.getLicence( 'cc-by-3.0' ),
+		evaluation = newEvaluation(
+			{},
+			{
+				'typeOfUse': { type: 'print' },
+				editing: { edited: 'true' },
+				licence: { licence: licence.getId() }
+			}
+		);
+
+	assert.ok( attributionContains( evaluation, Messages.t( 'evaluation.edited' ) + ', ' + licence.getUrl() ) );
+	assert.notOk( attributionContains( evaluation, ' ' + Messages.t( 'evaluation.by' ) + ' ' ) );
+} );
+
 QUnit.test( 'online attribution contains author\'s html', function( assert ) {
 	var authorUrl = 'https://commons.wikimedia.org/wiki/User:Foo',
 		author = 'Foo',


### PR DESCRIPTION
…vided. Do not included change author part in attribution if none provided.

Task: https://phabricator.wikimedia.org/T120954 + https://phabricator.wikimedia.org/T120955
Demo: https://tools.wmflabs.org/file-reuse-test/editing-attribution/redesign/