### PR TITLE
Improve attribution scraping

### DIFF
--- a/js/app/DialogueEvaluation.js
+++ b/js/app/DialogueEvaluation.js
@@ -110,7 +110,7 @@ $.extend( DialogueEvaluation.prototype, {
 		if( this.isPrint() ) {
 			return notEmpty && attributionText;
 		}
-		return notEmpty && ( this._asset.getAttribution().html() || attributionText );
+		return notEmpty && ( $( '<div/>' ).append( this._asset.getAttribution() ).html() || attributionText );
 	},
 
 	_getPrintAttribution: function() {


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T121511
Demo: http://tools.wmflabs.org/file-reuse-test/improve_attribution_scraping/

It should now get the correct attribution for files like `https://commons.wikimedia.org/wiki/File:ChineseLimmat.jpg` (attribution in the summary table) and `https://commons.wikimedia.org/wiki/File:Flughahn.jpg` (attribution contains HTML)