### PR TITLE
Fix isSubstep logic.

### DIFF
--- a/js/app/views/ProgressBarView.js
+++ b/js/app/views/ProgressBarView.js
@@ -60,7 +60,7 @@ $.extend( ProgressBarView.prototype, {
 
 					return {
 						name: 'dialogue.' + step.getName(),
-						isSubstep: i !== lastStepIndex && ( i >= 4 || allSteps.length < 8 && i >= 3 ),
+						isSubstep: i !== lastStepIndex && allSteps.length > 5 && i >= lastStepIndex - 3,
 						isActive: i === activeStep,
 						isCompleted: i < activeStep
 					};

--- a/tests/app/ProgressBarView.tests.js
+++ b/tests/app/ProgressBarView.tests.js
@@ -13,6 +13,10 @@ QUnit.test( 'should have 5 steps by default', function( assert ) {
 	assert.equal( new ProgressBarView( Helpers.newDefaultAttributionDialogue() ).render().find( 'li' ).length, 5 );
 } );
 
+QUnit.test( 'should initially not have any substeps', function( assert ) {
+	assert.equal( new ProgressBarView( Helpers.newDefaultAttributionDialogue() ).render().find( '.sub' ).length, 0 );
+} );
+
 QUnit.test( 'should have only 4 steps if the author is known', function( assert ) {
 	var asset = new Asset( '', '', null, null, [ new Author( $( 'Meh' ) ) ] ),
 		dialogue = new AttributionDialogue( asset ),


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T122795
Demo: http://tools.wmflabs.org/file-reuse-test/substep_fix/

Enter `https://commons.wikimedia.org/wiki/File:Karl-Marx-Allee_Frankfurter_Tor_Turm_Schild.jpg`. "Bearbeitung" should not be a substep anymore now.