### PR TITLE
Ignore GET params when parsing the input URL

### DIFF
--- a/js/app/InputHandler.js
+++ b/js/app/InputHandler.js
@@ -125,6 +125,12 @@ $.extend( InputHandler.prototype, {
 			matches,
 			segments;
 
+		if( url.indexOf( 'title=' ) !== -1 ) {
+			matches = url.match( /title=([^&]+)/i );
+			return matches[ 1 ];
+		}
+		url = url.replace( /\?.+$/, '' );
+
 		key = '#mediaviewer/';
 		keyLoc = url.indexOf( key );
 
@@ -137,11 +143,6 @@ $.extend( InputHandler.prototype, {
 
 		if( keyLoc !== -1 ) {
 			return url.substr( keyLoc + key.length );
-		}
-
-		if( url.indexOf( 'title=' ) !== -1 ) {
-			matches = url.match( /title=([^&]+)/i );
-			return matches[ 1 ];
 		}
 
 		key = 'wiki/';
@@ -183,9 +184,7 @@ $.extend( InputHandler.prototype, {
 			matches = url.match( regExp1 );
 			wikiUrl = 'https://' + matches[ 1 ] + '/';
 
-			title = url.indexOf( 'title=' ) !== -1
-				? url.match( /title=([^&]+)/i )[ 1 ]
-				: this._extractPageTitle( url.replace( /\?.+$/, '' ), false );
+			title = this._extractPageTitle( url, false );
 
 		} else if( regExp2.test( url ) ) {
 			matches = url.match( regExp2 );

--- a/tests/app/InputHandler.local.tests.js
+++ b/tests/app/InputHandler.local.tests.js
@@ -24,7 +24,10 @@ var testCases = [
 			'http://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
 			'http://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',
 			'upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',
-			'http://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg#mediaviewer/File:Helene_Fischer_2010.jpg'
+			'http://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg#mediaviewer/File:Helene_Fischer_2010.jpg',
+			'commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?uselang=de',
+			'https://commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
+			'commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar'
 		],
 		expected: {
 			file: 'File:Helene_Fischer_2010.jpg',


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T122799
Demo: https://tools.wmflabs.org/file-reuse-test/url-params/

Try e.g. `https://commons.wikimedia.org/wiki/File:Karl-Marx-Allee_Frankfurter_Tor_Turm_Schild.jpg?uselang=de` as an input