### PR TITLE
When loading asset of unsupported media type show error message conce…

### DIFF
--- a/js/app/FileForm.js
+++ b/js/app/FileForm.js
@@ -123,16 +123,14 @@ $.extend( FileForm.prototype, {
 		self._api.getAsset( prefixedFilename, wikiUrl )
 			.done( function( asset ) {
 				if( asset instanceof WikiAsset ) {
-					if( asset.getLicence() !== null && asset.getLicence().isInGroup( 'unsupported' ) ) {
+					if( $.inArray( asset.getMediaType(), config.supportedMediaTypes ) === -1 ) {
+						self._displayError( new ApplicationError( 'mediatype-unsupported' ) );
+						return;
+					} else if( asset.getLicence() !== null && asset.getLicence().isInGroup( 'unsupported' ) ) {
 						self._displayError( new ApplicationError( 'licence-unsupported' ) );
 						return;
 					} else if( asset.getLicence() === null ) {
 						self._displayError( new ApplicationError( 'licence-not-recognized' ) );
-						return;
-					} else if(
-						$.inArray( asset.getMediaType(), config.supportedMediaTypes ) === -1
-					) {
-						self._displayError( new ApplicationError( 'mediatype-unsupported' ) );
 						return;
 					}
 				}


### PR DESCRIPTION
…rning the media type

Task: https://phabricator.wikimedia.org/T122796
Demo: https://tools.wmflabs.org/file-reuse-test/unsupported-mediatype-error/

As mentioned in the phab ticket, when video/audio/whatever else is loaded and no licence template is detected, tool shows the error message saying that licence is not supported or so ("Es tut uns leid, aber dieses Bild wird aufgrund des Lizenzformats derzeit noch nicht unterstützt. ")
Try for instance:
`https://commons.wikimedia.org/wiki/File:Eisenhower_video_montage.ogg`
or the audio file `https://commons.wikimedia.org/wiki/File:Anne_of_avonlea_30_montgomery.ogg`

In really little frequent (it took me some time to find example on Commons) cases where file of unsupported type has unsupported CC-BY licence, the wrong error message is shown too ("Leider wird die ermittelte Lizenz des Bildes von dieser Anwendung nicht unterstützt. "), see:
`https://commons.wikimedia.org/wiki/File:French_Island_Echidna.ogg` (licensed under CC-BY-2.1-AU)

With this change in all above cases error message about the unsupported media type will be shown "Der Medientyp der angegebenen Datei wird von dieser Applikation momentan leider nicht unterstützt. ".