### PR TITLE
Change Public Domain information text

### DIFF
--- a/js/i18n.json
+++ b/js/i18n.json
@@ -15,11 +15,11 @@
       "ported-licence": "Bestimmte Creative-Commons-Lizenzen wurden in speziellen Länderversionen veröffentlicht, so genannte portierte Lizenzen. Das von Ihnen angefragte Werk wurde unter einer solchen portierten Lizenz veröffentlicht. Es wurde nicht geprüft, ob die Lizenzpflichten dieser Länderversion der deutschen Sprachversion entsprechen. Sie können den Lizenzhinweis gern mit diesem Tool erstellen. Um ganz sicherzugehen, empfehlen wir Ihnen, die Lizenzpflichten anhand des Lizenztextes zu überprüfen. Der Lizenzhinweis ist zusätzlich an die Sprache des Nutzungskontextes anzupassen."
     },
     "dialogue": {
-      "public-domain-picture": "Dieses Bild ist gemeinfrei. Es ist keine Lizenzangabe nötig.",
+      "public-domain-picture": "Für dieses Bild ist keine Lizenzangabe nötig.",
       "no-attribution-needed": "Keine Lizenzangabe nötig",
       "more-information": "weitere Informationen",
       "adjust-attribution-for-usage": "Lizenzhinweis an die Nutzung anpassen",
-      "public-domain-text": "<p>Bei der Nutzung von Werken, die als gemeinfrei gekennzeichnet sind, bestehen keine Lizenzpflichten. Sie können in jeder beliebigen Form genutzt werden, ohne dass Hinweise auf den Urheber oder die Lizenzierung gemacht werden müssen.</p><p>Laut deutschem Urheberrecht hält der Urheber allerdings einen nicht verzichtbaren Kern an Rechten. Wir raten deshalb davon ab, sich die Urheberschaft an dem Werk anzumaßen oder es in einer Weise zu benutzen, die den Ruf des Urhebers schädigt.</p>",
+      "public-domain-text": "<p>Bei der Nutzung dieses Werkes bestehen keine Lizenzpflichten. Es kann in jeder beliebigen Form genutzt werden, ohne dass Hinweise auf den Urheber oder die Lizenzierung gemacht werden müssen.</p><p>Laut deutschem Urheberrecht hält der Urheber allerdings einen nicht verzichtbaren Kern an Rechten. Wir raten deshalb davon ab, sich die Urheberschaft an dem Werk anzumaßen oder es in einer Weise zu benutzen, die den Ruf des Urhebers schädigt.</p>",
       "type-of-use-headline": "Wie möchten Sie das Werk nutzen?",
       "author-headline": "Wie lautet der Name bzw. die Namen des Ursprungsautors oder der Rechteinhaber?",
       "compilation-headline": "Wie möchten Sie das Werk veröffentlichen?",


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T123466
Demo: https://tools.wmflabs.org/file-reuse-test/pd-msg

Note: Phabricator task states "For all CC-0 and PD-Templates the text should be as follows:" whereas currently that text has been only shown for PD stuff, CC-0 goes through the steps as other recognized licences. I don't know if whether this is still OK, so I am making this remark here.