### PR TITLE
Recognize "Copyrighted free use" licence template

### DIFF
--- a/js/app/LICENCES.js
+++ b/js/app/LICENCES.js
@@ -40,7 +40,7 @@ module.exports = [
 	new Licence( 'cc', [ 'unsupported' ], [], 'CC', /CC-BY/i ),
 
 	new Licence( 'cc-zero', [ 'cc', 'cc0' ], [], 'CC0 1.0', /^(cc-zero|Bild-CC-0)/i, 'https://creativecommons.org/publicdomain/zero/1.0/legalcode' ),
-	new Licence( 'PD', [ 'pd' ], [], 'Public Domain', /^(Bild-)?(PD|Public domain)\b/i ),
+	new Licence( 'PD', [ 'pd' ], [], 'Public Domain', /^(Bild-)?(PD|Public domain|Copyrighted free use)\b/i ),
 
 	new Licence( 'unknown', [ 'unknown' ], [], 'Unknown', '', '' )
 ];

--- a/tests/app/LicenceStore.tests.js
+++ b/tests/app/LicenceStore.tests.js
@@ -10,6 +10,10 @@ QUnit.test( 'detects Public Domain', function( assert ) {
 	assert.equal( licences.detectLicence( 'PD-self' ).getName(), 'Public Domain' );
 } );
 
+QUnit.test( 'detects Copyrighted free use', function( assert ) {
+	assert.equal( licences.detectLicence( 'Copyrighted free use' ).getName(), 'Public Domain' );
+} );
+
 QUnit.test( 'detects CC BY 1.0', function( assert ) {
 	assert.equal( licences.detectLicence( 'Cc-by-1.0' ).getName(), 'CC BY 1.0' );
 } );


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T123465
Demo: https://tools.wmflabs.org/file-reuse-test/copyrighted-free-use-licence

Test with e.g.: https://commons.wikimedia.org/wiki/File:Blaikiewell_snowdrops.jpg or https://commons.wikimedia.org/wiki/File:02_meidum_pyramid.jpg.

I am not sure what licence is this "Copyrighted free use" template actually referring to. As might be seen using the demo URL, currently it is CC-0 (as commons template sort of suggests, not the PD). But I have no idea whether it is at all OK. This would be changed accordingly once someone with knowledge has commented.