### PR TITLE
Show information on no attribution required instead of dialogue for pictures with cc-zero template

### DIFF
--- a/js/app/views/DialogueScreen.js
+++ b/js/app/views/DialogueScreen.js
@@ -34,14 +34,15 @@ $.extend( DialogueView.prototype, {
 	},
 
 	/**
-	 * Renders information about Public Domain Licence if the picture was under PD or starts the dialogue
+	 * Renders information about the usage not requiring attributing the author,
+	 * if the asset has been licenced under appropriate licence, or starts the dialogue otherwise.
 	 *
 	 * @param {jQuery} $screen
 	 */
 	render: function( $screen ) {
 		var title, dialogue;
 
-		if( this._asset.getLicence().isInGroup( 'pd' ) ) {
+		if( this._noAttributionNeeded( this._asset.getLicence() ) ) {
 			title = Messages.t( 'dialogue.no-attribution-needed' );
 			dialogue = new PublicDomainDialogueView;
 		} else {
@@ -54,7 +55,17 @@ $.extend( DialogueView.prototype, {
 			imagePreview: this._renderImagePreview()
 		} ) );
 		dialogue.render( $screen.find( '.dialogue' ) );
+	},
+
+	/**
+	 * Checks if the licence does not oblige to provide the attribution
+	 *
+	 * @param {Licence} licence
+	 */
+	_noAttributionNeeded: function( licence ) {
+		return licence.isInGroup( 'pd' ) || licence.isInGroup( 'cc0' );
 	}
+
 } );
 
 module.exports = DialogueView;

--- a/tests/app/DialogueScreen.tests.js
+++ b/tests/app/DialogueScreen.tests.js
@@ -1,0 +1,40 @@
+'use strict';
+
+QUnit.module( 'DialogueScreen' );
+
+var Asset = require( '../../js/app/Asset' ),
+	DialogueScreen = require( '../../js/app/views/DialogueScreen' ),
+	ImageInfo = require( '../../js/app/ImageInfo' ),
+	LicenceStore = require( '../../js/app/LicenceStore' ),
+	licences = new LicenceStore( require( '../../js/app/LICENCES' ) ),
+	Messages = require( '../../js/app/Messages' ),
+	$ = require( 'jquery' );
+
+function newDialogueScreenForLicence( licenceId ) {
+	return new DialogueScreen(
+		new ImageInfo( 'foo', 'bar', 1337, { url: 'baz', width: 1337, height: 1337 } ),
+		new Asset( '', '', licences.getLicence( licenceId ), null, [] )
+	);
+}
+
+function dialogueHeaderContains( $dialogue, text ) {
+	return $dialogue.find( '.dialogue-header' ).text().indexOf( Messages.t( text ) ) > -1;
+}
+
+QUnit.test( 'Given Public Domain asset, no atribution obligation information is displayed', function( assert ) {
+	var $dialogue = $( '<div/>' );
+	newDialogueScreenForLicence( 'PD' ).render( $dialogue );
+	assert.ok( dialogueHeaderContains( $dialogue, 'dialogue.no-attribution-needed' ) );
+} );
+
+QUnit.test( 'Given CC0 asset, no atribution obligation information is displayed', function( assert ) {
+	var $dialogue = $( '<div/>' );
+	newDialogueScreenForLicence( 'cc-zero' ).render( $dialogue );
+	assert.ok( dialogueHeaderContains( $dialogue, 'dialogue.no-attribution-needed' ) );
+} );
+
+QUnit.test( 'Given asset licenced under CC-BY-SA-4.0, the dialogue is displayed', function( assert ) {
+	var $dialogue = $( '<div/>' );
+	newDialogueScreenForLicence( 'cc-by-sa-4.0' ).render( $dialogue );
+	assert.ok( dialogueHeaderContains( $dialogue, 'dialogue.adjust-attribution-for-usage' ) );
+} );

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -4,6 +4,7 @@ require( 'qunitjs' );
 require( '../js/view_helpers' );
 require( './app/Api.local.tests' );
 require( './app/InputHandler.local.tests' );
+require( './app/DialogueScreen.tests' );
 require( './app/DialogueStep.tests' );
 require( './app/Dialogue.tests' );
 require( './app/AttributionDialogue.tests' );


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T123625
Demo: https://tools.wmflabs.org/file-reuse-test/no-attribution-cc0/

examples: `https://commons.wikimedia.org/wiki/File:Mona_Lisa.jpg` (PD template), `https://commons.wikimedia.org/wiki/File:%22Bisonte_a_la_vista%22_%282%29.jpg` (cc-zero)

See also: https://github.com/wmde/Lizenzverweisgenerator/pull/199#issuecomment-171586077