### PR TITLE
Start spinners before evaluating the input, so spinners are properly …

### DIFF
--- a/js/app/FileForm.js
+++ b/js/app/FileForm.js
@@ -52,8 +52,8 @@ $.extend( FileForm.prototype, {
 
 	_submit: function( e ) {
 		this._$resultsPage.hide();
-		this._evaluateInput( this._$node.find( 'input' ).val() );
 		this._indicateLoading();
+		this._evaluateInput( this._$node.find( 'input' ).val() );
 		e.preventDefault();
 	},
 


### PR DESCRIPTION
…stopped when the input processing fails (due to invalid URL for instance).

Task: https://phabricator.wikimedia.org/T123709
Demo: https://tools.wmflabs.org/file-reuse-test/fix-no-error-msg-on-wrong-input/

I just noticed that when one enters non-Wikipedia and non-Commons URL (or simply some foobar contant) to the input field, the tool does not show an error message (you can see the error in the browser console when trying the input on the production instance for example).
Apparently, this got broken when adding the loading spinners. This change simply starts spinners no matter what the input was. That way spinner stopping function will always have a spinner to stop, and also spinner wouldn't start if the input was wrong (the latter would happen if I simply check for spinner's existence in the `_stopLoading` method).