### PR TITLE
Get all the templates

### DIFF
--- a/js/app/Api.js
+++ b/js/app/Api.js
@@ -103,7 +103,7 @@ $.extend( Api.prototype, {
 			rvprop: 'content',
 			rvparse: 1
 		} )
-			.done( function( page, ajaxOptions ) {
+			.done( function( page ) {
 				if( !page.revisions || page.revisions.length === 0 || !page.revisions[ 0 ][ '*' ] ) {
 					deferred.reject( new ApplicationError( 'revision-invalid' ) );
 					return;
@@ -136,7 +136,7 @@ $.extend( Api.prototype, {
 			tlnamespace: 10,
 			tllimit: 100
 		} )
-			.done( function( page, ajaxOptions ) {
+			.done( function( page ) {
 				if( !page.templates ) {
 					deferred.reject( new ApplicationError( 'templates-missing' ) );
 					return;
@@ -176,7 +176,7 @@ $.extend( Api.prototype, {
 			iiurlwidth: size,
 			iiurlheight: size
 		} )
-			.done( function( page, ajaxOptions ) {
+			.done( function( page ) {
 				if( !page.imageinfo || page.imageinfo[ 0 ].length === 0 ) {
 					deferred.reject( new ApplicationError( 'imageinfo-missing' ) );
 					return;
@@ -208,7 +208,7 @@ $.extend( Api.prototype, {
 			iiprop: 'mediatype|url',
 			iilimit: 1
 		} )
-			.done( function( page, ajaxOptions ) {
+			.done( function( page ) {
 				if( !page.imageinfo ) {
 					deferred.resolve( 'unknown' );
 					return;
@@ -373,7 +373,6 @@ $.extend( Api.prototype, {
 	 * @return {Object} jQuery Promise
 	 *         Resolved parameters:
 	 *         - {Object[]}
-	 *         - {Object} Options $.ajax() has been initiated with
 	 *         Rejected parameters:
 	 *         - {ApplicationError}
 	 */
@@ -419,9 +418,9 @@ $.extend( Api.prototype, {
 				} );
 
 				if( pages.length === 1 ) {
-					deferred.resolve( pages[ 0 ], ajaxOptions );
+					deferred.resolve( pages[ 0 ] );
 				} else if( pages.length > 0 ) {
-					deferred.resolve( pages, ajaxOptions );
+					deferred.resolve( pages );
 				} else if( errorCode ) {
 					deferred.reject( new ApplicationError( errorCode ) );
 				} else {

--- a/js/config.json
+++ b/js/config.json
@@ -1,4 +1,5 @@
 {
+  "apiContinuationLimit": 10,
   "supportedMediaTypes": ["bitmap", "drawing"],
   "piwikUrl": "https://lizenzhinweisgenerator.wmflabs.org/piwik/",
   "piwikSiteId": 1

--- a/tests/LocalApi.js
+++ b/tests/LocalApi.js
@@ -38,7 +38,7 @@ $.extend( LocalApi.prototype, Api.prototype, {
 	 *         Rejected parameters:
 	 *         - {ApplicationError}
 	 */
-	_query: function( title, property, wikiUrl, params ) {
+	_getResultsFromApi: function( title, property, wikiUrl, params ) {
 		return this._readFile( this._getLocalFilename( title, property, params ) );
 	},
 


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T123520
Demo: https://tools.wmflabs.org/file-reuse-test/api-continuation/

The problem that has been discovered using: `https://commons.wikimedia.org/wiki/File:Mona_Lisa,_by_Leonardo_da_Vinci,_from_C2RMF_retouched.jpg`. The page of that file has some 147 templates or so, while the tool has been only fetching 100 templates. That was usually OK but as the licence templates of the Mona Lisa didn't make it in the first hundred, the tool assumed there is no known licence template, and showed the relevant error message.
The quick fix would be probably increasing the number of templates fetched for a page (API's limit being 500) but I doubt it is a way to go. API offers a possibility to continue the previous query if number of stuffs to return is bigger than requested amount (100 in our case).
This patch intends to use this feature of the API. (At least) in theory, it should be used for all other API calls tool is doing, not only templates, but as I find it rather unlikely that it makes any sense in other types of queries, only template query uses it for now.

I am not super happy with the way those recursive deferred/promise objects are done here, so I'd be glad to see some comments and suggestions how to make it cleaner.