### PR TITLE
Do not accept empty author in the "Author" step. Not specifying author's na…

### DIFF
--- a/js/app/templates/AuthorStep.handlebars
+++ b/js/app/templates/AuthorStep.handlebars
@@ -11,7 +11,7 @@
 	{{/inline}}
 
 	{{#*inline 'content'}}
-		<form class="immediate-submit">
+		<form class="immediate-submit author-step">
 			<p>{{translate 'dialogue.author-label'}}</p>
 
 			<div class="form-group checkbox">

--- a/js/app/views/AttributionDialogueView.js
+++ b/js/app/views/AttributionDialogueView.js
@@ -138,6 +138,10 @@ $.extend( AttributionDialogueView.prototype, {
 			$( this ).closest( 'form' ).submit();
 		} );
 		$content.find( 'form' ).submit( function( e ) {
+			if( !self._validateForm( $( e.target ) ) ) {
+				e.preventDefault();
+				return false;
+			}
 			self._submit( e, $dialogue );
 		} );
 		$content.find( '.question-mark' ).click( this._toggleQuestionMark );
@@ -147,7 +151,16 @@ $.extend( AttributionDialogueView.prototype, {
 
 		$dialogue.html( $content );
 		$content.find( 'input:text' ).focus();
+	},
+
+	_validateForm: function( $form ) {
+		return !$form.hasClass( 'author-step' ) || this._validateAuthorStepForm( $form );
+	},
+
+	_validateAuthorStepForm: function( $form ) {
+		return $form.find( 'input:checkbox[name="no-author"]' ).is( ':checked' ) || $form.find( 'input:text[name="author"]' ).val();
 	}
+
 } );
 
 module.exports = AttributionDialogueView;

--- a/tests/app/AttributionDialogueView.tests.js
+++ b/tests/app/AttributionDialogueView.tests.js
@@ -52,7 +52,7 @@ QUnit.test( 'clicking a checkbox on first step submits and saves data', function
 	assert.equal( dialogue._dialogue.getData()[ 'typeOfUse' ][ 'type' ], 'print' );
 } );
 
-QUnit.test( 'submitting the form should renders second step', function( assert ) {
+QUnit.test( 'submitting the form should render second step', function( assert ) {
 	var $dialogue = $( '<div/>' );
 	Helpers.newDefaultAttributionDialogueView().render( $dialogue );
 
@@ -74,6 +74,21 @@ QUnit.test( 'Author Step', function( assert ) {
 	dialogue.dom.find( 'input:text' ).val( 'Blah' );
 	dialogue.dom.find( 'button' ).click();
 	assert.equal( dialogue.view._dialogue.getData()[ 'author' ][ 'author' ], 'Blah' );
+} );
+
+QUnit.test( 'Author Step does not accept empty author name', function( assert ) {
+	var dialogue = renderDialogueAtStep( 1 );
+
+	dialogue.dom.find( 'button' ).click();
+
+	assert.ok( dialogueContains( dialogue.dom, 'dialogue.author-headline' ) );
+	assert.notOk( dialogueContains( dialogue.dom, 'dialogue.compilation-headline' ) );
+
+	dialogue = renderDialogueAtStep( 1 );
+	dialogue.dom.find( 'input:text' ).trigger( $.Event( 'keydown', { which: 13 } ) );
+
+	assert.ok( dialogueContains( dialogue.dom, 'dialogue.author-headline' ) );
+	assert.notOk( dialogueContains( dialogue.dom, 'dialogue.compilation-headline' ) );
 } );
 
 QUnit.test( 'Compilation Step', function( assert ) {


### PR DESCRIPTION
…me should only be possible by ticking the "Author name is not known" checkbox.

Task: https://phabricator.wikimedia.org/T123475
Demo: https://tools.wmflabs.org/file-reuse-test/no-empty-author

Try out e.g. with `https://commons.wikimedia.org/wiki/File:Karl-Marx-Allee_Frankfurter_Tor_Turm_Schild.jpg`.

I believe this could done in multiple different, this is actually my third attempt :) I'd appreciate if better way is suggested.

First I tried to disable submit button of the form, and only enable it when something is typed to the input field. That wouldn't easily work for cases when the name is pasted into the field and not actually typed (which I imagine is a common scenario when author's name is not in user's native language; I believe the only German name I could spell without an error would be Oliver Kahn). It would also require triggering some `key*` events in several tests, so they still pass, which I'd consider evil. So I dropped this way.
Then I tried to add some custom handlers for clicking submit button and changing contents of the input field but again it turned to be far more complex than I believe this change should be.

So I ended up by adding an extra check to the submit handler of the form. At least in theory it could be expanded with some more custom checks for other steps etc.