### PR TITLE
Do not show the scrollbar when displaying the two-column PD informati…

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -468,6 +468,7 @@ a:hover {
   -webkit-column-gap: 40px;
   -moz-column-gap: 40px;
   column-gap: 40px;
+  overflow: hidden;
 }
 .dialogue-bubble .bubble-columns p {
   break-after: column;


### PR DESCRIPTION
…on text

Task: https://phabricator.wikimedia.org/T123738
Demo: https://tools.wmflabs.org/file-reuse-test/chrome-extra-space/

Example picture: `https://commons.wikimedia.org/wiki/File:Brandenburger-Tor-1735-Daniel-Chodowiecki-1764.jpg`
Apparently problem only occurs in Chrome/Chromium (although not all versions as I remember @jakobw saying it is not appearing for him in Chrome?). It would still be nice to check how those columns look in IE.

For the Chrome part:
Looks like setting ` -webkit-column-break-after: always;` to columns adds some sort of extra padding/margin to the container object. I didn't manage to figure out what `<div>` is actually affected and how but setting the `overflow` of the `div` immediate containing the column seems to solve the problem in the sense that the horizontal scrollbar is not shown even if the extra space is added.

Any better ideas how to "fix" that?