### PR TITLE
Do not include progress bar placeholder in the PD information view

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -356,6 +356,13 @@ a:hover {
   width: 50vw;
   font-size: 12pt;
 }
+.dialogue-bubble {
+  display: table;
+  width: 100%;
+}
+.dialogue-bubble .animated-content {
+  display: table-cell;
+}
 .dialogue-bubble h2 {
   color: #4b590a;
   font-size: 12pt;
@@ -377,7 +384,7 @@ a:hover {
   background: #97b314;
   border-radius: 2px;
   padding: 10px;
-  margin: 0 0 0 175px;
+  margin: 0 0 0 20px;
 }
 .dialogue-bubble .bubble-text {
   color: #fff;
@@ -618,9 +625,9 @@ a:hover {
 }
 
 .ag-progress-bar {
-  float: left;
   width: 155px;
   padding: 10px 0 0 25px;
+  display: table-cell;
 }
 .ag-progress-bar li {
   list-style-type: none;

--- a/js/app/templates/Dialogue.handlebars
+++ b/js/app/templates/Dialogue.handlebars
@@ -15,6 +15,4 @@
 			</div>
 		</div>
 	</div>
-
-	<div class="clearfix"></div>
 </div>

--- a/js/app/templates/Dialogue.handlebars
+++ b/js/app/templates/Dialogue.handlebars
@@ -1,5 +1,7 @@
 <div class="dialogue-bubble">
-	<div class="ag-progress-bar"></div><!-- .progress-bar is used by bootstrap -->
+	{{#unless noProgressBar}}
+		<div class="ag-progress-bar"></div><!-- .progress-bar is used by bootstrap -->
+	{{/unless}}
 
 	<div class="animated-content">
 		<div class="triangle"></div>

--- a/js/app/templates/PublicDomain.handlebars
+++ b/js/app/templates/PublicDomain.handlebars
@@ -1,4 +1,4 @@
-{{#>dialogueBubble}}
+{{#>dialogueBubble noProgressBar=1}}
 	{{#*inline 'title'}}
 		{{translate 'dialogue.public-domain-picture'}}
 	{{/inline}}

--- a/js/app/views/DialogueEvaluationView.js
+++ b/js/app/views/DialogueEvaluationView.js
@@ -136,9 +136,10 @@ $.extend( DialogueEvaluationView.prototype, {
 	},
 
 	render: function() {
-		var $html = $( doneTemplate() ),
+		var $html = $( '<div/>' ),
 			dosAndDonts = this._evaluation.getDosAndDonts();
 
+		$html.append( doneTemplate() );
 		$html.append( attributionTemplate( {
 			attribution: this._evaluation.getAttribution(),
 			plainTextAttribution: this._evaluation.getPlainTextAttribution(),
@@ -170,7 +171,7 @@ $.extend( DialogueEvaluationView.prototype, {
 
 		this._initCopyButton( $html.find( '#copy-attribution' ) );
 
-		return $html;
+		return $html.contents();
 	}
 } );
 


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T123737
Demo: https://tools.wmflabs.org/file-reuse-test/pd-bubble/

Tested in Firefox and Chromium so far.
CSS table display [wouldn't work in IE 7](http://caniuse.com/#feat=css-table) but this is not the IE version that should be supported, right?

https://github.com/wmde/Lizenzverweisgenerator/commit/8154f049ee62e2e13e5e95e6e9d890adca31eff9 is not directly related to the change requested in the phab task but after doing other changes I have noticed that evaluation view is broken as all stuff below the dialogue "Done" message (in the bubble) is put into the same row as the the bubble (due to those other elements being chidren of the `dialogue-bubble` `<div>`). I guess this is not correct (compare also `<div>` structure in the PD view). I can also move this commit to the separate PR if intended.


