### PR TITLE
Handle other Commons URLs than file page 

### DIFF
--- a/js/app/Api.js
+++ b/js/app/Api.js
@@ -253,7 +253,7 @@ $.extend( Api.prototype, {
 
 		this._getMetaData( title, wikiUrl )
 			.done( function( metaData ) {
-				if( $.inArray( metaData.mediatype, config.supportedMediaTypes ) !== -1 ) {
+				if( typeof metaData === 'object' && metaData.mediatype ) {
 					deferred.resolve( title, metaData.url );
 					return;
 				}

--- a/js/app/InputHandler.js
+++ b/js/app/InputHandler.js
@@ -71,20 +71,25 @@ $.extend( InputHandler.prototype, {
 	_evaluate: function( url ) {
 		var deferred = $.Deferred();
 
-		if(
-			url.indexOf( '.wikipedia.org/w' ) !== -1
-			|| url.indexOf( 'upload.wikimedia.org/wikipedia/' ) !== -1
-			&& url.indexOf( '/wikipedia/commons/' ) === -1
-		) {
+		if( this._isWikiUrl( url ) ) {
 			return this._getWikipediaPageImagesFileInfo( url );
-		} else if( url.indexOf( '.wikimedia.org/' ) !== -1 ) {
-			var urlInfo = this._splitUrl( url );
-			deferred.resolve( urlInfo.title, urlInfo.wikiUrl );
 		} else {
 			deferred.reject( new ApplicationError( 'url-invalid' ) );
 		}
 
 		return deferred.promise();
+	},
+
+	/**
+	 * @param {string} url
+	 * @return {boolean}
+	 */
+	_isWikiUrl: function( url ) {
+		return url.indexOf( '.wikipedia.org/w' ) !== -1
+			|| (
+				url.indexOf( 'upload.wikimedia.org/wikipedia/' ) !== -1 && url.indexOf( '/wikipedia/commons/' ) === -1
+			)
+			|| url.indexOf( 'wikimedia.org/' ) !== -1;
 	},
 
 	/**

--- a/tests/app/InputHandler.local.tests.js
+++ b/tests/app/InputHandler.local.tests.js
@@ -102,6 +102,14 @@ var testCases = [
 			file: 'File:Commodore_Plus_4_Knurri.png',
 			wikiUrl: 'https://commons.wikimedia.org/'
 		}
+	}, {
+		input: [
+			'https://commons.wikimedia.org/wiki/File:A_Punjab_Village,_1925.webm'
+		],
+		expected: {
+			file: 'File:A_Punjab_Village,_1925.webm',
+			wikiUrl: 'https://commons.wikimedia.org/'
+		}
 	}
 ];
 

--- a/tests/app/InputHandler.local.tests.js
+++ b/tests/app/InputHandler.local.tests.js
@@ -178,6 +178,14 @@ QUnit.test( 'getFilename() returning ImageInfo objects', function( assert ) {
 			expected: {
 				wikiUrl: 'https://de.wikipedia.org/'
 			}
+		}, {
+			input: [
+				'https://commons.wikimedia.org/wiki/User:Seeteufel',
+				'commons.wikimedia.org/wiki/User:Seeteufel'
+			],
+			expected: {
+				wikiUrl: 'https://commons.wikimedia.org/'
+			}
 		}
 	];
 

--- a/tests/fixtures/imageinfo/Anime-Cosplay 14.JPG.json
+++ b/tests/fixtures/imageinfo/Anime-Cosplay 14.JPG.json
@@ -1,0 +1,15 @@
+{
+	"pageid": 14660210,
+	"ns": 6,
+	"title": "File:Anime-Cosplay 14.JPG",
+	"imagerepository": "local",
+	"imageinfo": [
+		{
+			"thumburl": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/76/Anime-Cosplay_14.JPG/300px-Anime-Cosplay_14.JPG",
+			"thumbwidth": 300,
+			"thumbheight": 212,
+			"url": "https://upload.wikimedia.org/wikipedia/commons/7/76/Anime-Cosplay_14.JPG",
+			"descriptionurl": "https://commons.wikimedia.org/wiki/File:Anime-Cosplay_14.JPG"
+		}
+	]
+}

--- a/tests/fixtures/images/Seeteufel.json
+++ b/tests/fixtures/images/Seeteufel.json
@@ -1,0 +1,11 @@
+{
+	"pageid": 1710912,
+	"ns": 2,
+	"title": "User:Seeteufel",
+	"images": [
+		{
+			"ns": 6,
+			"title": "File:Anime-Cosplay 14.JPG"
+		}
+	]
+}

--- a/tests/fixtures/metadata/A_Punjab_Village,_1925.webm.json
+++ b/tests/fixtures/metadata/A_Punjab_Village,_1925.webm.json
@@ -1,0 +1,13 @@
+{
+	"pageid": 45093094,
+	"ns": 6,
+	"title": "File:A Punjab Village, 1925.webm",
+	"imagerepository": "local",
+	"imageinfo": [
+		{
+			"url": "https://upload.wikimedia.org/wikipedia/commons/8/8e/A_Punjab_Village%2C_1925.webm",
+			"descriptionurl": "https://commons.wikimedia.org/wiki/File:A_Punjab_Village,_1925.webm",
+			"mediatype": "VIDEO"
+		}
+	]
+}

--- a/tests/fixtures/metadata/Anime-Cosplay_14.JPG.json
+++ b/tests/fixtures/metadata/Anime-Cosplay_14.JPG.json
@@ -1,0 +1,13 @@
+{
+	"pageid": 14660210,
+	"ns": 6,
+	"title": "File:Anime-Cosplay 14.JPG",
+	"imagerepository": "local",
+	"imageinfo": [
+		{
+			"url": "https://upload.wikimedia.org/wikipedia/commons/7/76/Anime-Cosplay_14.JPG",
+			"descriptionurl": "https://commons.wikimedia.org/wiki/File:Anime-Cosplay_14.JPG",
+			"mediatype": "BITMAP"
+		}
+	]
+}

--- a/tests/fixtures/metadata/Seeteufel.json
+++ b/tests/fixtures/metadata/Seeteufel.json
@@ -1,0 +1,5 @@
+{
+	"pageid": 1710912,
+	"ns": 2,
+	"title": "User:Seeteufel"
+}


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T123914
Demo: https://tools.wmflabs.org/file-reuse-test/all-from-commons/

Boring description what this change is about:
 - currently Commons URLs have been treated differently than Wikipedia URLs etc in that manner that if Commons URL has been an input than it has been assumed that it is a file page URL, and API has been asked to provide the media/image info. For Wikipedia URLs API first checks if the URL contains any media (ie. if it is a file page), and if not images contained by the page (e.g. pictures in the wikipedia article) are fetched through API.
 - this reasoning lead to the problem described in the Phabricator ticket: when other Commons URL than file page has been inserted unpredictable things happened: sometimes tool has shown an error message, sometimes tool has just crashed (there were some clues in browser's js console but for user tool basically hanged),
 - this patch changes the way of handling input so all URLs are now first checked whether they're media/file pages, or "just" articles with media in them. https://github.com/wmde/Lizenzverweisgenerator/commit/03749448a26ad8d1376dccadfb9e53d77cafad47 is basically about that,
 - I also made a slight change to the code getting media type, so it also returns information on media type for things the tool does not handle yet (e.g. videos) - this what https://github.com/wmde/Lizenzverweisgenerator/commit/120573e973f363a46e8368c1eb93ec6d103b1f93 is for. Without that when given video from Commons, the tool would not say that "sorry the tool does not currently support files of that media type" but would rather assume that some non-file page has been inserted, and grab all images from the file page of the video. That code is a remnant from the old version, media type check is now performed elsewhere (see `js/app/FileForm.js`). Also added a video test case, so such things get noticed easier (I only noticed it by accident when had almost opened a PR with the former commit only)