### PR TITLE
When displaying an error message scroll up to the input box, so the e…

### DIFF
--- a/js/app/FileForm.js
+++ b/js/app/FileForm.js
@@ -200,6 +200,8 @@ $.extend( FileForm.prototype, {
 		$( '#file-form-alert-placeholder' ).text( error.getMessage() );
 		$( '#file-form-input' ).css( 'color', '#bf311a' );
 		$( '#file-form-alert' ).slideDown();
+
+		this._scrollToResults();
 	},
 
 	/**


### PR DESCRIPTION
…rror message is always visible

Task: https://phabricator.wikimedia.org/T123710
Demo: https://tools.wmflabs.org/file-reuse-test/scroll-to-error

Try out for example with `https://de.wikipedia.org/wiki/DFB-Pokal_1976/77` (almost all images in this article are copyrighted). Tool should now scroll up to make an error message visible.