### PR TITLE
Show error message if wiki page is missing

### DIFF
--- a/js/app/Api.js
+++ b/js/app/Api.js
@@ -435,7 +435,7 @@ $.extend( Api.prototype, {
 					var isSharedImage = params['prop'] === 'imageinfo' && page.imagerepository === 'shared';
 
 					if( page.missing !== undefined && !isSharedImage ) {
-						errorCode = 'page-missing';
+						errorCode = 'url-invalid';
 					} else if( page.invalid !== undefined ) {
 						errorCode = 'page-invalid';
 					} else {


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T124759
Demo: https://tools.wmflabs.org/file-reuse-test/page-missing-error-msg/

Sample input:
`https://commons.wikimedia.org/wiki/SuperMegaAwesome.jpg`
`https://de.wikipedia.org/wiki/Jimmy_Naked`

Combined with https://github.com/wmde/Lizenzverweisgenerator/pull/207 would also show the message for `https://commons.wikimedia.org/wiki/User:Christoph_Fischer_%28WMDE%29`