### PR TITLE
Show error message when there is no images in the wiki page instead of doing nothing.

### DIFF
--- a/js/app/Api.js
+++ b/js/app/Api.js
@@ -301,6 +301,10 @@ $.extend( Api.prototype, {
 
 		this._getResultsFromApi( title, 'images', wikiUrl, params )
 			.done( function( page ) {
+				if( page.images === undefined || page.images.length === 0  ) {
+					deferred.reject( new ApplicationError( 'url-invalid' ) );
+					return;
+				}
 				var imageTitles = [];
 
 				for( var i = 0; i < page.images.length; i++ ) {

--- a/tests/app/InputHandler.local.tests.js
+++ b/tests/app/InputHandler.local.tests.js
@@ -225,13 +225,14 @@ QUnit.test( 'getFilename() returning ImageInfo objects', function( assert ) {
 	}
 } );
 
-QUnit.test( 'getFilename returns an error when given non-wikimedia/wikipedia URL', function( assert ) {
+QUnit.test( 'getFilename returns an error when given an URL that cannot be processed', function( assert ) {
 	var inputHandler = new InputHandler( api );
 
 	var testCases = [
 		'https://www.wikimedia.de/w/images.homepage/d/d6/Pavel_Richter_WMDE.JPG',
 		'https://www.wikimedia.de/w/images.homepage/d/d6/',
-		'http://foo.bar'
+		'http://foo.bar',
+		'https://de.wikipedia.org/wiki/Lars_Kindgen'
 	];
 
 	/**

--- a/tests/fixtures/images/Lars_Kindgen.json
+++ b/tests/fixtures/images/Lars_Kindgen.json
@@ -1,0 +1,5 @@
+{
+	"pageid": 8776953,
+	"ns": 0,
+	"title": "Lars Kindgen"
+}

--- a/tests/fixtures/metadata/Lars_Kindgen.json
+++ b/tests/fixtures/metadata/Lars_Kindgen.json
@@ -1,0 +1,5 @@
+{
+	"pageid": 8776953,
+	"ns": 0,
+	"title": "Lars Kindgen"
+}


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T124760
Demo: https://tools.wmflabs.org/file-reuse-test/no-images-error-msg/

Sample input:
`https://de.wikipedia.org/wiki/Lars_Kindgen`
`https://fr.wikipedia.org/wiki/Aide:Comment_cr%C3%A9er_un_article`
Redirects are also considered by tool as pages with no images, see e.g. `https://de.wikipedia.org/wiki/Tschunk`

Combined with https://github.com/wmde/Lizenzverweisgenerator/pull/207 would also show an error message for things like `https://commons.wikimedia.org/wiki/Commons:Contact_us`