### PR TITLE
Get all the images from an article

### DIFF
--- a/js/app/Api.js
+++ b/js/app/Api.js
@@ -299,7 +299,7 @@ $.extend( Api.prototype, {
 			format: 'json'
 		};
 
-		this._getResultsFromApi( title, 'images', wikiUrl, params )
+		this._getResultsFromApi( title, 'images', wikiUrl, params, 'imcontinue' )
 			.done( function( page ) {
 				if( page.images === undefined || page.images.length === 0  ) {
 					deferred.reject( new ApplicationError( 'url-invalid' ) );

--- a/js/app/Api.js
+++ b/js/app/Api.js
@@ -483,7 +483,7 @@ $.extend( Api.prototype, {
 				continuationCount++;
 
 				if( self._continuationNeeded( response, continuationParam, continuationCount ) ) {
-					params['tlcontinue'] = response.continue[continuationParam];
+					params[continuationParam] = response.continue[continuationParam];
 					return self._query( wikiUrl, params, continuationParam, continuationCount, deferred, pages );
 				}
 

--- a/js/app/Api.js
+++ b/js/app/Api.js
@@ -339,23 +339,54 @@ $.extend( Api.prototype, {
 			return deferred.promise();
 		}
 
+		this._getImageInfoBatch( imageTitles, wikiUrl, new $.Deferred(), [] )
+			.done( function( imageInfos ) {
+				deferred.resolve( imageInfos );
+			} )
+			.fail( function( error ) {
+				deferred.reject( error );
+			} );
+
+		return deferred.promise();
+	},
+
+	/**
+	 * Retrieves image info for a batch of (max 50) images. Continues with another batch if more images has been
+	 * passed in.
+	 *
+	 * @param {string[]} titles
+	 * @param {string} wikiUrl
+	 * @param {Object} deferred jQuery Deferred object instance shared by consecutive queries
+	 * @param {ImageInfo[]} imageInfos image info data collected by previous queries
+	 * @return {Object} jQuery Promise
+	 *         Resolved parameters:
+	 *         - {ImageInfo[]}
+	 *         Rejected parameters:
+	 *         - {ApplicationError}
+	 */
+	_getImageInfoBatch: function( titles, wikiUrl, deferred, imageInfos ) {
 		var params = {
 			iiprop: 'url',
 			iilimit: 1,
 			iiurlheight: 300
-		};
+		},
+			self = this,
+			titleLimit = 50,
+			titleSubset = titles.slice( 0, Math.min( titleLimit, titles.length ) );
 
-		this._getResultsFromApi( imageTitles, 'imageinfo', wikiUrl, params )
+		this._getResultsFromApi( titleSubset, 'imageinfo', wikiUrl, params )
 			.done( function( pages ) {
 				if( !$.isArray( pages ) ) {
 					pages = [ pages ];
 				}
 
-				var imageInfos = [];
-
 				$.each( pages, function( index, page ) {
 					imageInfos.push( ImageInfo.newFromMediaWikiImageInfoJson( page.imageinfo[ 0 ] ) );
 				} );
+
+				if( titles.length > titleLimit ) {
+					return self._getImageInfoBatch( titles.slice( titleSubset.length ), wikiUrl, deferred, imageInfos );
+				}
 
 				deferred.resolve( imageInfos );
 			} )


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T124756
Demo: https://tools.wmflabs.org/file-reuse-test/moar-images/

So this is about changing two things:
 - getting a complete list of images in the article by using `imcontinue` parameter of API query
 - getting image infos (thumbnail, description page url etc) in series of max. 50 images at a time. API only accept 50 "titles" in single query and simply drops all above 50. 

Some tests cases:
 - `https://fi.wikipedia.org/wiki/Jääkiekon_nuorten_maailmanmestaruuskilpailut_2016` - it has 54 images, without the latter part of the change only 50 images have been displayed.
 - `https://de.wikipedia.org/wiki/DFB-Pokal_1976/77` - this has 126 images, so it actually makes use of both parts of the change. With only former only 76 images would be displayed. With only latter part only 100 images would be displayed.

In order to e.g. see how many images are loaded by code of PR's branch and the current master, number of images in the "gallery" could be counted for example with `$('.jg-entry').length`.

This PR also contains https://github.com/wmde/Lizenzverweisgenerator/commit/461d6326b6518836bf7cffdf05ac11f34e79f6ec which doesn't really belong to the task but it fixes a bug that I have only noticed while working on that. Without this change tool would make 10 actually the same queries and show each of images 10 times. Good that @addshore suggested introducing the recursion limit, otherwise it would be making queries for ever. 