### PR TITLE
Hide the error message after selecting the image from the "gallery"

### DIFF
--- a/js/app/FileForm.js
+++ b/js/app/FileForm.js
@@ -205,9 +205,9 @@ $.extend( FileForm.prototype, {
 	},
 
 	/**
-	 * Displays an error on the front-page.
+	 * Dismisses an error on the front-page.
 	 */
-	_dismissError: function() {
+	dismissError: function() {
 		$( '#file-form-input' ).removeAttr( 'style' );
 		$( '#file-form-alert' ).slideUp();
 	},
@@ -237,6 +237,7 @@ $.extend( FileForm.prototype, {
 			self = this;
 
 		$suggestion.on( 'click', function( e ) {
+			self.dismissError();
 			self._evaluateInput( imageInfo.getDescriptionUrl() );
 			self._imageLoadingSpinner = new Spinner( $( this ) );
 			self._imageLoadingSpinner.add();

--- a/js/main.js
+++ b/js/main.js
@@ -67,7 +67,7 @@ $( '#how-it-works-screen .close' ).click( function() {
 
 $( '#file-form-input' ).on( 'input', function() {
 	// TODO only dismiss if error is present
-	fileForm._dismissError();
+	fileForm.dismissError();
 } );
 
 var bootstrapAlert = function( type, message ) {


### PR DESCRIPTION
Demo: https://tools.wmflabs.org/file-reuse-test/dismiss-error-gallery/

To see what this is about (on [master](https://tools.wmflabs.org/file-reuse-test/dismiss-error-gallery/)):
 - enter `https://de.wikipedia.org/wiki/DFB-Pokal`,
 - when images have loaded, click the UEFA logo,
 - error message regarding image's licence appears,
 - click Commons logo,
 - screen scrolls down and shows information about PD usage of Commons logo,

BUT: once you scroll back up to the input field the error message is still there. That might be confusing for the user