### PR TITLE
Only specify directory where Piwik is installed, and require it to be…

### DIFF
--- a/js/config.json
+++ b/js/config.json
@@ -1,6 +1,6 @@
 {
   "apiContinuationLimit": 10,
   "supportedMediaTypes": ["bitmap", "drawing"],
-  "piwikUrl": "https://lizenzhinweisgenerator.wmflabs.org/piwik/",
+  "piwikDir": "/piwik/",
   "piwikSiteId": 1
 }

--- a/js/tracking.js
+++ b/js/tracking.js
@@ -7,7 +7,7 @@
 var $ = require( 'jquery' ),
 	cookie = require( 'cookie' ),
 	config = require( './config.json' ),
-	piwik = require( 'piwik' ).setup( config.piwikUrl );
+	piwik = require( 'piwik' ).setup( window.location.host + config.piwikDir );
 
 /**
  * Tracking Handler.
@@ -38,7 +38,7 @@ $.extend( Tracking.prototype, {
 	_piwikSiteId: null,
 
 	/**
-	 * Track an event to piwik is allowed by the user
+	 * Track an event to piwik if allowed by the user
 	 * @param category
 	 * @param action
 	 * @param name
@@ -81,7 +81,7 @@ $.extend( Tracking.prototype, {
 	},
 
 	/**
-	 * Track a pageload to piwik is allowed by the user
+	 * Track a pageload to piwik if allowed by the user
 	 * @param pageName
 	 */
 	trackPageLoad: function( pageName ) {


### PR DESCRIPTION
… installed on the same host as the AG tool.

This is in order to have tracking working no matter user visits lizenzhinweisgenerator.de or lizenzhinweisgenerator.wmflabs.org

I am not very happy with that solution, feel free to suggest something better.