### PR TITLE
Include protocol in the Piwik URL

### DIFF
--- a/js/tracking.js
+++ b/js/tracking.js
@@ -7,7 +7,8 @@
 var $ = require( 'jquery' ),
 	cookie = require( 'cookie' ),
 	config = require( './config.json' ),
-	piwik = require( 'piwik' ).setup( window.location.host + config.piwikDir );
+	piwikUrl = 'https://' + window.location.host + config.piwikDir,
+	piwik = require( 'piwik' ).setup( piwikUrl );
 
 /**
  * Tracking Handler.


### PR DESCRIPTION
Silly me, missed the protocol in https://github.com/wmde/Lizenzverweisgenerator/pull/215 which breaks tracking (without the protocol part tool is trying to load something like `https://www.foo.bar/www.foo.bar/piwik/piwik.php`)
Still, I wonder why that change seemed to work for me when I tested it locally

Forcing HTTPS in the setting, not asking for `window.location.protocol` in case it happened to be http for whatever reason.