### PR TITLE
Work around ScrollMagic/GSAP 3.x incompatibility

### DIFF
--- a/js/scrolling_effects.js
+++ b/js/scrolling_effects.js
@@ -1,26 +1,32 @@
 'use strict';
 
 var $ = require( 'jquery' ),
-	ScrollMagic = require( 'scrollmagic' );
-require( 'gsap' );
+	ScrollMagic = require( 'scrollmagic' ),
+	gsapModule = require( 'gsap' );
+
+var gsap = ( gsapModule && ( gsapModule.gsap || gsapModule.default ) ) || gsapModule;
+
+// workaround for ScrollMagic - GSAP 3.x incompatibility
+window.gsap = gsap;
+window.TweenMax = gsap;
+window.TweenLite = gsap;
+window.TimelineMax = gsap.core && gsap.core.Timeline ? gsap.core.Timeline : ( gsap.timeline ? gsap.timeline : undefined );
 require( 'scrollmagic-gsap' );
 
 var controller = new ScrollMagic.Controller();
 
-var fadeHeadingUp = TweenMax.fromTo(
+var fadeHeadingUp = gsap.fromTo(
 	'.top-wrapper',
-	1,
 	{ opacity: 0, top: '15%' },
-	{ opacity: 1, top: 0 }
+	{ opacity: 1, top: 0, duration: 1 }
 );
-var moveTextboxUp = TweenMax.fromTo(
+var moveTextboxUp = gsap.fromTo(
 	'#file-form',
-	1,
 	{ top: 0 },
-	{ top: '60%', ease: Linear.easeNone }
+	{ top: '60%', ease: 'none', duration: 1 }
 );
 
-var upTweens = new TimelineMax();
+var upTweens = gsap.timeline();
 upTweens.add( [ fadeHeadingUp, moveTextboxUp ] );
 
 var upSceneOffset = function() {
@@ -39,23 +45,20 @@ $( window ).resize( function() {
 	up.offset( upSceneOffset() );
 } );
 
-var moveTextboxDown = TweenMax.to(
+var moveTextboxDown = gsap.to(
 	'#file-form',
-	1,
-	{ top: '100%', marginTop: '-82px' }
+	{ top: '100%', marginTop: '-82px', duration: 1 }
 );
-var fadeHeadingDown = TweenMax.to(
+var fadeHeadingDown = gsap.to(
 	'.top-wrapper',
-	1,
-	{ marginTop: '20vh', opacity: 0 }
+	{ marginTop: '20vh', opacity: 0, duration: 1 }
 );
-var fadeAttributionDown = TweenMax.to(
+var fadeAttributionDown = gsap.to(
 	'.attribution',
-	1,
-	{ bottom: '20%', opacity: 0 }
+	{ bottom: '20%', opacity: 0, duration: 1 }
 );
 
-var downTweens = new TimelineMax();
+var downTweens = gsap.timeline();
 downTweens.add( [ fadeHeadingDown, moveTextboxDown, fadeAttributionDown ] );
 
 var down = new ScrollMagic.Scene( {

--- a/package.json
+++ b/package.json
@@ -18,21 +18,21 @@
     "browserify": "^17.0.0",
     "hbsfy": "^2.4.1",
     "qunitjs": "^1.19.0",
-    "uglify-js": "^2.4.24",
+    "uglify-js": "^3.19.3",
     "watchify": "^4.0.0"
   },
   "dependencies": {
     "bootstrap": "^3.3.5",
     "clipboard": "^1.5.5",
     "cookie": "^0.2.3",
-    "gsap": "^3.10.4",
+    "gsap": "^3.13.0",
     "handlebars": "^4.0.3",
     "jquery": "^3.0.0",
     "justifiedGallery": "git+https://github.com/miromannino/Justified-Gallery.git#60d253d6963750db2507571612ae0c2d7c2f970d",
     "node-polyglot": "^0.4.3",
     "piwik": "^1.0.4",
     "require-globify": "^1.3.0",
-    "scrollmagic": "^2.0.5",
+    "scrollmagic": "^2.0.8",
     "zeroclipboard": "^2.2.0"
   }
 }


### PR DESCRIPTION
A previous major bump of GSAP has caused an incompatibility with ScrollMagic. This patch works around it.